### PR TITLE
Rename to EntityFramework.MicrosoftSqlServer

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Data.EntityFramework/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Data.EntityFramework/project.json
@@ -2,7 +2,7 @@
   "version": "2.0.0-*",
   "dependencies": {
     "EntityFramework.Core": "7.0.0-*",
-    "EntityFramework.SqlServer": "7.0.0-*",
+    "EntityFramework.MicrosoftSqlServer": "7.0.0-*",
     "EntityFramework.InMemory": "7.0.0-*",
     "Orchard.DependencyInjection": "2.0.0-*",
     "Orchard.Data": "2.0.0-*",


### PR DESCRIPTION
The new version of EF for compatibility with EF6 has been renamed to EntityFramework.MicrosoftSqlServer