### PR TITLE
New command

### DIFF
--- a/src/Orchard.Web/project.json
+++ b/src/Orchard.Web/project.json
@@ -22,6 +22,7 @@
   },
   "commands": {
     "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5001",
+    "webdev": "Microsoft.AspNet.Hosting --aspnet_env development --server Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5001",
     "run": "run"
   },
   "compilationOptions": {


### PR DESCRIPTION
In `DefaultRoslynCompilationService` this test has been added:

            if (_hostingEnvironment.IsDevelopment())

The issue is that, in the last dnx version I use, it always return false. See here: https://github.com/aspnet/Hosting/blob/dev/src/Microsoft.AspNet.Hosting/HostingEnvironment.cs

There are some solutions by code, but a quick workaround is to use under VS2015 a new `webdev` command with an additional argument to specify the environment name.

Best