### PR TITLE
Views compilation: always adds missing references in GetApplicationReferences().

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -10,6 +10,8 @@ SET skipdnvm=%1
 call dnu clear-http-cache
 cd src/orchard.web/modules
 call dnu restore
+cd../themes
+call dnu restore
 cd../core
 call dnu restore
 cd../../..


### PR DESCRIPTION
Always adds the missing references (whatever the compiler) through the lazy `_applicationReferences` value factory, instead of doing this in the `Compile()` call. And removes unecessary test and related code...

Best