### PR TITLE
Experimental test to speed up and decreases memory

### DIFF
--- a/src/Orchard.Environment.Extensions/ExtensionAssemblyLoader.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionAssemblyLoader.cs
@@ -16,6 +16,7 @@ namespace Orchard.Environment.Extensions
     {
         private readonly IApplicationEnvironment _applicationEnvironment;
         //private readonly ICache _cache;
+        private readonly CompilationCache _compilationCache = new CompilationCache();
         private readonly IAssemblyLoadContextAccessor _assemblyLoadContextAccessor;
         private readonly IRuntimeEnvironment _runtimeEnvironment;
         private readonly IOrchardLibraryManager _libraryManager;
@@ -75,7 +76,7 @@ namespace Orchard.Environment.Extensions
                 _applicationEnvironment,
                 _runtimeEnvironment,
                 _assemblyLoadContextAccessor.Default,
-                new CompilationCache()));
+                _compilationCache));
 
             var exporter = engine.CreateProjectExporter(
                 moduleContext.Project, moduleContext.TargetFramework, _applicationEnvironment.Configuration);


### PR DESCRIPTION
Related to #118

In an experimental test with only 2 tenants, if in `ExtensionAssemblyLoader.cs` we always use the same `CompilationCache` the first request is much faster and uses less memory...

Not sure we can do this for thread safety, but for more details see #118.

Best