### PR TITLE
vscode & portable pdb & static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,7 @@ log.xml
 profiling/
 *.orig
 .vs/
-.vscode/
+#.vscode/
 .build/
 .testPublish/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": ".NET Core Launch (console)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "Dotnet Build Debug",
+			"program": "${workspaceRoot}/src/Orchard.Web/bin/Debug/netstandardapp1.5/Orchard.Web.dll",
+			"args": [],
+			"cwd": "${workspaceRoot}/src/Orchard.Web",
+			"stopAtEntry": false
+		},
+		{
+			"name": ".NET Core Launch (web)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "Dotnet Build Debug",
+			"program": "${workspaceRoot}/src/Orchard.Web/bin/Debug/netstandardapp1.5/Orchard.Web.dll",
+			"args": [],
+			"cwd": "${workspaceRoot}/src/Orchard.Web",
+			"stopAtEntry": false,
+			"launchBrowser": {
+				"enabled": true,
+				"args": "${auto-detect-url}",
+				"windows": {
+					"command": "cmd.exe",
+					"args": "/C start http://localhost:5000"
+				},
+				"osx": {
+					"command": "open"
+				},
+				"linux": {
+					"command": "xdg-open"
+				}
+			}
+		},
+		{
+			"name": ".NET Core Attach",
+			"type": "coreclr",
+			"request": "attach",
+			"processId": "*"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "0.1.0",
+	"command": "cmd",
+	"isShellCommand": true,
+	"args": ["/C"],
+	"showOutput": "always",
+	"suppressTaskName": true,
+	"tasks": [
+		{
+			"taskName": "Dotnet Restore",
+			"args": [ "dotnet restore" ]
+		},
+		{
+			"taskName": "Dotnet Force Restore",
+			"args": [ "dotnet restore --no-cache" ]
+		},
+		{
+			"taskName": "Dotnet Rebuild Debug",
+			"args": [ "dotnet build ${workspaceRoot}/src/Orchard.Web --no-incremental -c Debug" ],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"taskName": "Dotnet Build Debug",
+			"args": [ "dotnet build ${workspaceRoot}/src/Orchard.Web -c Debug" ],
+			"isBuildCommand": true,
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"taskName": "Dotnet Build Release",
+			"args": [ "dotnet build ${workspaceRoot}/src/Orchard.Web -c Release" ],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"taskName": "Dotnet Run",
+			"args": [ "cd ${workspaceRoot}/src/orchard.web & dotnet run" ]
+		},
+		{
+			"taskName": "Gulp Build",
+			"args": [ "gulp build" ],
+            "problemMatcher": "$gulp-tsc"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
 	"version": "0.1.0",
 	"command": "cmd",
 	"isShellCommand": true,
@@ -39,7 +37,7 @@
 		{
 			"taskName": "Gulp Build",
 			"args": [ "gulp build" ],
-            "problemMatcher": "$gulp-tsc"
+			"problemMatcher": "$gulp-tsc"
 		}
 	]
 }

--- a/src/Orchard.Abstractions/project.json
+++ b/src/Orchard.Abstractions/project.json
@@ -11,6 +11,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.ContentManagement.Display/project.json
+++ b/src/Orchard.ContentManagement.Display/project.json
@@ -7,6 +7,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.ContentManagement/project.json
+++ b/src/Orchard.ContentManagement/project.json
@@ -12,6 +12,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Data/project.json
+++ b/src/Orchard.Data/project.json
@@ -14,6 +14,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.DependencyInjection/project.json
+++ b/src/Orchard.DependencyInjection/project.json
@@ -8,6 +8,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.DisplayManagement/project.json
+++ b/src/Orchard.DisplayManagement/project.json
@@ -14,6 +14,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Cache.Abstractions/project.json
+++ b/src/Orchard.Environment.Cache.Abstractions/project.json
@@ -8,6 +8,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Cache/project.json
+++ b/src/Orchard.Environment.Cache/project.json
@@ -11,6 +11,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Commands/project.json
+++ b/src/Orchard.Environment.Commands/project.json
@@ -8,6 +8,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Extensions.Abstractions/project.json
+++ b/src/Orchard.Environment.Extensions.Abstractions/project.json
@@ -9,7 +9,8 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
-    "warningsAsErrors": true
+     "debugType": "portable",
+   "warningsAsErrors": true
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/Orchard.Environment.Extensions/project.json
+++ b/src/Orchard.Environment.Extensions/project.json
@@ -13,6 +13,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Navigation/project.json
+++ b/src/Orchard.Environment.Navigation/project.json
@@ -10,6 +10,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Recipes/project.json
+++ b/src/Orchard.Environment.Recipes/project.json
@@ -8,6 +8,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Shell.Abstractions/project.json
+++ b/src/Orchard.Environment.Shell.Abstractions/project.json
@@ -10,6 +10,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Environment.Shell/project.json
+++ b/src/Orchard.Environment.Shell/project.json
@@ -22,6 +22,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Events/project.json
+++ b/src/Orchard.Events/project.json
@@ -7,6 +7,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.FileSystem/project.json
+++ b/src/Orchard.FileSystem/project.json
@@ -11,7 +11,8 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
-    "warningsAsErrors": true
+    "debugType": "portable",
+   "warningsAsErrors": true
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/Orchard.Hosting.Console/project.json
+++ b/src/Orchard.Hosting.Console/project.json
@@ -9,6 +9,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "commands": {

--- a/src/Orchard.Hosting.Web/project.json
+++ b/src/Orchard.Hosting.Web/project.json
@@ -24,6 +24,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Hosting/project.json
+++ b/src/Orchard.Hosting/project.json
@@ -13,6 +13,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Parser.Yaml/project.json
+++ b/src/Orchard.Parser.Yaml/project.json
@@ -9,7 +9,8 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
-    "warningsAsErrors": true
+    "debugType": "portable",
+   "warningsAsErrors": true
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/Orchard.Security/project.json
+++ b/src/Orchard.Security/project.json
@@ -7,6 +7,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Validation/project.json
+++ b/src/Orchard.Validation/project.json
@@ -5,6 +5,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Web/Core/Orchard.Core/Dashboard/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Core/Orchard.Core/Dashboard/Controllers/AdminController.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Orchard.DisplayManagement.Admin;
 
-namespace Orchard.Core.Dashboard
+namespace Orchard.Core.Dashboard.Controllers
 {
     [Admin]
     public class AdminController : Controller

--- a/src/Orchard.Web/Core/Orchard.Core/project.json
+++ b/src/Orchard.Web/Core/Orchard.Core/project.json
@@ -13,6 +13,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/project.json
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/project.json
@@ -9,6 +9,9 @@
     "Orchard.Core": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.Contents/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Contents/project.json
@@ -9,6 +9,9 @@
     "Orchard.Core": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.Demo/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Demo/project.json
@@ -8,6 +8,9 @@
     "Orchard.ContentManagement.Display": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.DynamicCache/project.json
+++ b/src/Orchard.Web/Modules/Orchard.DynamicCache/project.json
@@ -10,6 +10,9 @@
     "Orchard.Environment.Navigation": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.Lists/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Lists/project.json
@@ -10,6 +10,9 @@
     "Orchard.Core": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.Logging.Console/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Logging.Console/project.json
@@ -7,6 +7,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Web/Modules/Orchard.Resources/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Resources/project.json
@@ -8,6 +8,9 @@
     "Orchard.Core": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Modules/Orchard.Setup/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Setup/project.json
@@ -8,6 +8,7 @@
   },
   "compilationOptions": {
     "define": [ "TRACE" ],
+    "debugType": "portable",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/src/Orchard.Web/Modules/Orchard.Themes/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Controllers/AdminController.cs
@@ -5,7 +5,7 @@ using Orchard.Themes.Models;
 using Orchard.Themes.Services;
 using System.Threading.Tasks;
 
-namespace Orchard.Demo.Controllers
+namespace Orchard.Themes.Controllers
 {
     [Admin]
     public class AdminController : Controller

--- a/src/Orchard.Web/Modules/Orchard.Themes/project.json
+++ b/src/Orchard.Web/Modules/Orchard.Themes/project.json
@@ -9,6 +9,9 @@
     "Orchard.Environment.Navigation": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Program.cs
+++ b/src/Orchard.Web/Program.cs
@@ -14,6 +14,7 @@ namespace Orchard.Console
                 .UseKestrel()
                 .UseDefaultHostingConfiguration(args)
                 .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseWebRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build();
 

--- a/src/Orchard.Web/Themes/SafeMode/project.json
+++ b/src/Orchard.Web/Themes/SafeMode/project.json
@@ -7,6 +7,9 @@
     "Orchard.ContentManagement": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/Orchard.Web/Themes/TheAdmin/Views/Layout.cshtml
@@ -9,7 +9,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="~/TheAdmin/Styles/TheAdmin.min.css">
+    <link rel="stylesheet" href="~/Themes/TheAdmin/Styles/TheAdmin.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 
     @await RenderSectionAsync("Header", required: false)
@@ -56,6 +56,6 @@
 
     <!-- jQuery first, then Bootstrap JS. -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-    <script src="~/TheAdmin/Scripts/TheAdmin.js"></script>
+    <script src="~/Themes/TheAdmin/Scripts/TheAdmin.js"></script>
 </body>
 </html>

--- a/src/Orchard.Web/Themes/TheAdmin/project.json
+++ b/src/Orchard.Web/Themes/TheAdmin/project.json
@@ -7,6 +7,9 @@
     "Orchard.ContentManagement": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/Themes/TheTheme/project.json
+++ b/src/Orchard.Web/Themes/TheTheme/project.json
@@ -7,6 +7,9 @@
     "Orchard.ContentManagement": "2.0.0",
     "Orchard.Hosting.Web": "2.0.0"
   },
+  "compilationOptions": {
+    "debugType": "portable"
+  },
   "frameworks": {
     "netstandard1.5": {
       "imports": [

--- a/src/Orchard.Web/project.json
+++ b/src/Orchard.Web/project.json
@@ -26,6 +26,7 @@
   },
   "compilationOptions": {
     "emitEntryPoint": true,
+    "debugType": "portable",
     "preserveCompilationContext": true
   },
   "frameworks": {


### PR DESCRIPTION
Allow to use vscode. On a fresh installation, i could restore, build, run / debug without using the bluid.cmd. You still need to install yourself the dotnet cli (or use once the build.cmd). And you have to install (can be done through the vscode app) the c# extension (provided by OmniSharp).

Please review some other little changes i needed to do in my tests. But not sure there are right.

- Basic tasks for vscode that can be completed.
- All project.json updated to make portable pdb.
- I needed to update `.gitignore` to allow `.vscode` (maybe i have to revert this one).
- ~~`"/Core/Orchard.Core/"` added to `viewLocations` in `ModuleViewLocationExpander.cs`~~.
- Replace `Orchard.Core.Dashboard` namespace to `Orchard.Core.Dashboard.Controllers`.
- `Orchard.Demo.Controllers` to `Orchard.Themes.Controllers` because in `Orchard.Themes` module.
- In `Program.cs` add `.UseWebRoot(Directory.GetCurrentDirectory())` to serve static files.
- In `TheAdmin/Views/Layout.cshtml` update some .css and .js URLs.

Best