### PR TITLE
[wip] Adding Browser Sync for live reload of Assets and .cshtml files.

### DIFF
--- a/Package.json
+++ b/Package.json
@@ -21,7 +21,8 @@
     "gulp-rename": "1.2.2",
     "gulp-concat": "2.6.0",
     "gulp-header": "1.8.2",
-    "gulp-eol": "0.1.2"
+    "gulp-eol": "0.1.2",
+    "browser-sync": "2.12.8"
   },
   "dependencies": { }
 }


### PR DESCRIPTION
Simple changes to gulpfile.js and packages.json file to support live reload of assets.
Right now you need to do ```gulp browser-sync``` from command line to start it.
Have'nt looked into the option of starting it through a VS Code launcher yet.