### PR TITLE
Storing resources assemblies in probing folders.

### DIFF
--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -334,7 +334,7 @@ namespace Orchard.Environment.Extensions.Compilers
                 }
             }
 
-            if (!CompilerUtility.GenerateNonCultureResources(context.ProjectFile, resgenFiles))
+            if (!CompilerUtility.GenerateNonCultureResources(context.ProjectFile, resgenFiles, Diagnostics))
             {
                 return _compiledLibraries[context.ProjectName()] = false;
             }
@@ -377,9 +377,14 @@ namespace Orchard.Environment.Extensions.Compilers
                 .OnOutputLine(line => Diagnostics.Add(line))
                 .Execute();
 
-            Debug.WriteLine(String.Empty);
-
             compilationResult = result.ExitCode == 0;
+
+            if (compilationResult)
+            {
+                compilationResult &= CompilerUtility.GenerateCultureResourceAssemblies(context.ProjectFile, cultureResgenFiles, references, Diagnostics);
+            }
+
+            Debug.WriteLine(String.Empty);
 
             if (compilationResult && Diagnostics.Count <= 0)
             {
@@ -404,11 +409,6 @@ namespace Orchard.Environment.Extensions.Compilers
 
             Debug.WriteLine($"Time elapsed {sw.Elapsed}");
             Debug.WriteLine(String.Empty);
-
-            if (compilationResult)
-            {
-                compilationResult &= CompilerUtility.GenerateCultureResourceAssemblies(context.ProjectFile, cultureResgenFiles, references);
-            }
 
             return _compiledLibraries[context.ProjectName()] = compilationResult;
         }

--- a/src/Orchard.Environment.Extensions/Compilers/CompilerUtility.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CompilerUtility.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.Compiler.Common;
@@ -44,7 +43,7 @@ namespace Orchard.Environment.Extensions.Compilers
             return GetCultureResourcesFromIncludeEntries(project, outputPath, compilationOptions);
         }
 
-        public static bool GenerateNonCultureResources(Project project, List<CompilerUtility.NonCultureResgenIO> resgenFiles)
+        public static bool GenerateNonCultureResources(Project project, List<CompilerUtility.NonCultureResgenIO> resgenFiles, IList<string> diagnostics)
         {
             foreach (var resgenFile in resgenFiles)
             {
@@ -54,7 +53,7 @@ namespace Orchard.Environment.Extensions.Compilers
 
                     if (outputResourceFile.Type != ResourceFileType.Resources)
                     {
-                        Debug.WriteLine("Resource output type not supported");
+                        diagnostics.Add("Resource output type not supported");
                         return false;
                     }
 
@@ -69,7 +68,7 @@ namespace Orchard.Environment.Extensions.Compilers
             return true;
         }
 
-        public static bool GenerateCultureResourceAssemblies(Project project, List<CompilerUtility.CultureResgenIO> cultureResgenFiles, List<string> referencePaths)
+        public static bool GenerateCultureResourceAssemblies(Project project, List<CompilerUtility.CultureResgenIO> cultureResgenFiles, List<string> referencePaths, IList<string> diagnostics)
         {
             foreach (var resgenFile in cultureResgenFiles)
             {
@@ -84,7 +83,7 @@ namespace Orchard.Environment.Extensions.Compilers
 
                 if (outputResourceFile.Type != ResourceFileType.Dll)
                 {
-                    Debug.WriteLine("Resource output type not supported");
+                    diagnostics.Add("Resource output type not supported");
                     return false;
                 }
 
@@ -100,7 +99,8 @@ namespace Orchard.Environment.Extensions.Compilers
                         outputStream,
                         metadata,
                         Path.GetFileNameWithoutExtension(outputResourceFile.File.Name),
-                        referencePaths.ToArray());
+                        referencePaths.ToArray(),
+                        diagnostics);
                 }
             }
 

--- a/src/Orchard.Environment.Extensions/Compilers/ResourceAssemblyGenerator.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/ResourceAssemblyGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -11,7 +10,7 @@ namespace Orchard.Environment.Extensions.Compilers
 {
     internal class ResourceAssemblyGenerator
     {
-        public static bool Generate(ResourceSource[] sourceFiles, Stream outputStream, AssemblyInfoOptions metadata, string assemblyName, string[] references)
+        public static bool Generate(ResourceSource[] sourceFiles, Stream outputStream, AssemblyInfoOptions metadata, string assemblyName, string[] references, IList<string> diagnostics)
         {
             if (sourceFiles == null)
             {
@@ -44,7 +43,8 @@ namespace Orchard.Environment.Extensions.Compilers
                 }
                 else
                 {
-                    throw new InvalidOperationException("Generation of resource assemblies from dll not supported");
+                    diagnostics.Add("Generation of resource assemblies from dll not supported");
+                    return false;
                 }
             }
 
@@ -63,12 +63,12 @@ namespace Orchard.Environment.Extensions.Compilers
 
             if (!result.Success)
             {
+                diagnostics.Add("Error occured while emiting resource assembly");
+
                 foreach (var diagnostic in result.Diagnostics)
                 {
-                    Debug.WriteLine(diagnostic.ToString());
+                    diagnostics.Add(diagnostic.ToString());
                 }
-
-                Debug.WriteLine("Error occured while emiting resource assembly");
             }
 
             return result.Success;

--- a/src/Orchard.Environment.Extensions/Compilers/ResourceAssemblyGenerator.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/ResourceAssemblyGenerator.cs
@@ -68,7 +68,7 @@ namespace Orchard.Environment.Extensions.Compilers
                     Debug.WriteLine(diagnostic.ToString());
                 }
 
-                throw new InvalidOperationException("Error occured while emiting assembly");
+                Debug.WriteLine("Error occured while emiting resource assembly");
             }
 
             return result.Success;

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -259,7 +259,6 @@ namespace Orchard.Environment.Extensions
 
                                 PopulateBinaryFolder(assemblyFolderPath, asset, locale);
                                 PopulateProbingFolder(asset, locale);
-                                PopulateRuntimeFolder(asset, locale);
                             }
                         }
                     }
@@ -303,7 +302,6 @@ namespace Orchard.Environment.Extensions
                                 {
                                     PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, locale);
                                     PopulateProbingFolder(assetResolvedPath, locale);
-                                    PopulateRuntimeFolder(assetResolvedPath, locale);
                                 }
                             }
                         }
@@ -352,7 +350,6 @@ namespace Orchard.Environment.Extensions
                                 {
                                     PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, asset.Culture);
                                     PopulateProbingFolder(assetResolvedPath, asset.Culture);
-                                    PopulateRuntimeFolder(assetResolvedPath, asset.Culture);
                                 }
                             }
                         }
@@ -384,7 +381,6 @@ namespace Orchard.Environment.Extensions
                             {
                                 PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, asset.Locale);
                                 PopulateProbingFolder(assetResolvedPath, asset.Locale);
-                                PopulateRuntimeFolder(assetResolvedPath, asset.Locale);
                             }
                         }
                     }
@@ -497,12 +493,6 @@ namespace Orchard.Environment.Extensions
         private void PopulateProbingFolder(string assetPath, string locale = null)
         {
             PopulateBinaryFolder(_probingFolderPath, assetPath, locale);
-        }
-
-        private void PopulateRuntimeFolder(string assetPath, string locale = null)
-        {
-            var runtimeDirectory = Path.GetDirectoryName(CSharpExtensionCompiler.EntryAssembly.Location);
-            PopulateBinaryFolder(runtimeDirectory, assetPath, locale);
         }
     }
 }


### PR DESCRIPTION
Just to finish a started work on resource files.

- Dynamic compilation / loading behaves as before as long as there are no resources files.

- Resource assemblies was generated, now there are also stored in modules bin folders and the `app_data/dependencies` folder (in subfolders according to their culture / locale).

- I think we don't need to load resources assemblies ourselves but not sure, will see if we need it.

Will see how dynamic compilation behaves, at least i think it will help for development. In production without core projects & packages storage, with precompiled modules ... , i opted for some solutions among others which have pros and cons. When it will be time, maybe i'll open an "issue" to summarize this.

Best