### PR TITLE
Fixes #189 Avoids Adding Twice a RunningShell creating a Site from scratch

### DIFF
--- a/src/Orchard.Environment.Shell.Abstractions/IRunningShellTable.cs
+++ b/src/Orchard.Environment.Shell.Abstractions/IRunningShellTable.cs
@@ -2,9 +2,8 @@
 {
     public interface IRunningShellTable
     {
-        bool TryAdd(ShellSettings settings);
+        void Store(ShellSettings settings);
         void Remove(ShellSettings settings);
-        void Update(ShellSettings settings);
         ShellSettings Match(string host, string appRelativeCurrentExecutionFilePath);
     }
 }

--- a/src/Orchard.Environment.Shell.Abstractions/IRunningShellTable.cs
+++ b/src/Orchard.Environment.Shell.Abstractions/IRunningShellTable.cs
@@ -2,7 +2,7 @@
 {
     public interface IRunningShellTable
     {
-        void Add(ShellSettings settings);
+        bool TryAdd(ShellSettings settings);
         void Remove(ShellSettings settings);
         void Update(ShellSettings settings);
         ShellSettings Match(string host, string appRelativeCurrentExecutionFilePath);

--- a/src/Orchard.Environment.Shell/RunningShellTable.cs
+++ b/src/Orchard.Environment.Shell/RunningShellTable.cs
@@ -12,7 +12,7 @@ namespace Orchard.Environment.Shell
         private ShellSettings _single;
         private ShellSettings _default;
 
-        public void Add(ShellSettings settings)
+        public bool TryAdd(ShellSettings settings)
         {
             _lock.EnterWriteLock();
             try
@@ -33,8 +33,11 @@ namespace Orchard.Environment.Shell
                 }
 
                 var hostAndPrefix = GetHostAndPrefix(settings);
+                if (_shellsByHostAndPrefix.ContainsKey(hostAndPrefix))
+                    return false;
                 _shellsByHostAndPrefix.Add(hostAndPrefix, settings);
-            }
+                return true;
+            }            
             finally
             {
                 _lock.ExitWriteLock();

--- a/src/Orchard.Environment.Shell/RunningShellTable.cs
+++ b/src/Orchard.Environment.Shell/RunningShellTable.cs
@@ -12,7 +12,7 @@ namespace Orchard.Environment.Shell
         private ShellSettings _single;
         private ShellSettings _default;
 
-        public bool TryAdd(ShellSettings settings)
+        public void Store(ShellSettings settings)
         {
             _lock.EnterWriteLock();
             try
@@ -33,10 +33,7 @@ namespace Orchard.Environment.Shell
                 }
 
                 var hostAndPrefix = GetHostAndPrefix(settings);
-                if (_shellsByHostAndPrefix.ContainsKey(hostAndPrefix))
-                    return false;
-                _shellsByHostAndPrefix.Add(hostAndPrefix, settings);
-                return true;
+                _shellsByHostAndPrefix[hostAndPrefix] = settings;                
             }            
             finally
             {
@@ -56,22 +53,7 @@ namespace Orchard.Environment.Shell
                 _lock.ExitWriteLock();
             }
         }
-
-        public void Update(ShellSettings settings)
-        {
-            _lock.EnterWriteLock();
-            try
-            {
-                var hostAndPrefix = GetHostAndPrefix(settings);
-                _shellsByHostAndPrefix.Remove(hostAndPrefix);
-                _shellsByHostAndPrefix.Add(hostAndPrefix, settings);
-            }
-            finally
-            {
-                _lock.ExitWriteLock();
-            }
-        }
-
+        
         public ShellSettings Match(string host, string appRelativePath)
         {
             _lock.EnterReadLock();

--- a/src/Orchard.Hosting/DefaultOrchardHost.cs
+++ b/src/Orchard.Hosting/DefaultOrchardHost.cs
@@ -146,7 +146,7 @@ namespace Orchard.Hosting
             }
             if (_shellContexts.TryAdd(context.Settings.Name, context))
             {
-                _runningShellTable.Add(context.Settings);
+                _runningShellTable.TryAdd(context.Settings);
             }
         }
 

--- a/src/Orchard.Hosting/DefaultOrchardHost.cs
+++ b/src/Orchard.Hosting/DefaultOrchardHost.cs
@@ -75,7 +75,7 @@ namespace Orchard.Hosting
             ShellContext context;
 
             _shellSettingsManager.SaveSettings(settings);
-            _runningShellTable.Update(settings);
+            _runningShellTable.Store(settings);
             _shellContexts.TryRemove(settings.Name, out context);
             context = CreateShellContext(settings);
             ActivateShell(context);
@@ -146,7 +146,7 @@ namespace Orchard.Hosting
             }
             if (_shellContexts.TryAdd(context.Settings.Name, context))
             {
-                _runningShellTable.TryAdd(context.Settings);
+                _runningShellTable.Store(context.Settings);
             }
         }
 


### PR DESCRIPTION
I'm not sure this is the best solution, but it was the most straight forward. 
A better one maybe would be to solve the root cause: when there is no tenants default one is the one running so we don't need to add it another time to running shells, but we still need to update _single and _default vars within RunningShellTable to take into account its new settings.