### PR TITLE
Lighter ambient assembly names list, without all native assets.

### DIFF
--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -13,7 +13,6 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Compilation;
-using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.DotNet.Tools.Common;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
@@ -84,12 +83,10 @@ namespace Orchard.Environment.Extensions
 
         private HashSet<string> GetApplicationAssemblyNames()
         {
-            var assemblyNames = new HashSet<string>(DependencyContext.Default.GetDefaultAssemblyNames()
-                .Select(x => x.Name), StringComparer.OrdinalIgnoreCase);
-
-            assemblyNames.UnionWith(DependencyContext.Default.RuntimeLibraries.Select(x => x.Name));
-
-            return assemblyNames;
+            return new HashSet<string>(DependencyContext.Default.RuntimeLibraries
+                .SelectMany(library => library.RuntimeAssemblyGroups)
+                .SelectMany(assetGroup => assetGroup.AssetPaths)
+                .Select(path => Path.GetFileNameWithoutExtension(path)));
         }
 
         private List<MetadataReference> GetMetadataReferences()

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -86,7 +86,8 @@ namespace Orchard.Environment.Extensions
             return new HashSet<string>(DependencyContext.Default.RuntimeLibraries
                 .SelectMany(library => library.RuntimeAssemblyGroups)
                 .SelectMany(assetGroup => assetGroup.AssetPaths)
-                .Select(path => Path.GetFileNameWithoutExtension(path)));
+                .Select(path => Path.GetFileNameWithoutExtension(path)),
+                StringComparer.OrdinalIgnoreCase);
         }
 
         private List<MetadataReference> GetMetadataReferences()


### PR DESCRIPTION
Before loading an assembly we check this list. We manage runtime assemblies and, recently, also according to different runtime identifiers. But, at least right now, we don't look up for native assets.

So, seems to be useless to have native assets in the list where we could save around 50 items.

Anyway, i think that for now it's a more consistent way to get all runtime assemblies. And, if we will also need to deal with native libraries, we'll found a better way.

Best.