### PR TITLE
Cleaner code for lazy initialization of AssemblyNames and MetadataReferences collections.

### DIFF
--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -384,13 +384,13 @@ namespace Orchard.Environment.Extensions.Compilers
 
             Debug.WriteLine(String.Empty);
 
-            if (compilationResult && Diagnostics.Count <= 0)
+            if (compilationResult && Diagnostics.Count == 0)
             {
                 Debug.WriteLine($"{context.ProjectName()}: Dynamic compilation succeeded.");
                 Debug.WriteLine($"0 Warning(s)");
                 Debug.WriteLine($"0 Error(s)");
             }
-            else if (result.ExitCode == 0 && Diagnostics.Count > 0)
+            else if (compilationResult && Diagnostics.Count > 0)
             {
                 Debug.WriteLine($"{context.ProjectName()}: Dynamic compilation succeeded but has warnings.");
                 Debug.WriteLine($"0 Error(s)");

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -179,32 +179,35 @@ namespace Orchard.Environment.Extensions
             var success = compiler.Compile(context, Configuration, _probingFolderPath);
             var diagnostics = compiler.Diagnostics;
 
-            if (success)
+            if (success && diagnostics.Count == 0)
             {
-                if (_logger.IsEnabled(LogLevel.Information) && !diagnostics.Any())
+                if (_logger.IsEnabled(LogLevel.Information))
                 {
-                     _logger.LogInformation($"{0} was successfully compiled", context.ProjectName());
+                    _logger.LogInformation($"{0} was successfully compiled", context.ProjectName());
                 }
-                else if (_logger.IsEnabled(LogLevel.Warning))
+            }
+            else if (success && diagnostics.Count > 0)
+            {
+                if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                     _logger.LogWarning($"{0} was compiled but has warnings", context.ProjectName());
+                    _logger.LogWarning($"{0} was compiled but has warnings", context.ProjectName());
 
-                     foreach (var diagnostic in diagnostics)
-                     {
-                         _logger.LogWarning(diagnostic);
-                     }
+                    foreach (var diagnostic in diagnostics)
+                    {
+                        _logger.LogWarning(diagnostic);
+                    }
                 }
             }
             else
             {
                 if (_logger.IsEnabled(LogLevel.Error))
                 {
-                     _logger.LogError($"{0} compilation failed", context.ProjectName());
+                    _logger.LogError($"{0} compilation failed", context.ProjectName());
 
-                     foreach (var diagnostic in diagnostics)
-                     {
-                         _logger.LogError(diagnostic);
-                     }
+                    foreach (var diagnostic in diagnostics)
+                    {
+                        _logger.LogError(diagnostic);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- **Update**: I've changed the title because finally, here, the main update is to use cleaner code for lazy initialization of `ApplicationAssemblyNames` and `MetadataReferences` collections. This by using `Lazy<T>` in place of the `LazyInitializer` class. According to the doc, using `LazyInitializer` is good in scenarios where you have to lazy-initialize a large number of objects, which is not our case here.

- **Minor Change**: With the current code, when compilation succeeds without any diagnostics messages (all is ok), if `LogLevel.Warning` is enabled but not `LogLevel.Information`, then a warning message would be wrongly logged.

Sorry, my mistake.