### PR TITLE
Store resource assemblies in runtime directory.

### DIFF
--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -128,7 +128,7 @@ namespace Orchard.Environment.Extensions.Compilers
                 // Compile other referenced libraries
                 if (library != null && !AmbientLibraries.Contains(library.Identity.Name) && dependency.CompilationAssemblies.Any())
                 {
-                    if (!_compiledLibraries.TryGetValue(library.Identity.Name, out compilationResult))
+                    if (!_compiledLibraries.ContainsKey(library.Identity.Name))
                     {
                         var projectContext = GetProjectContextFromPath(library.Project.ProjectDirectory);
 

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.Loader;
-using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -243,6 +242,7 @@ namespace Orchard.Environment.Extensions
 
                                 PopulateBinaryFolder(assemblyFolderPath, asset, locale);
                                 PopulateProbingFolder(asset, locale);
+                                PopulateRuntimeFolder(asset, locale);
                             }
                         }
                     }
@@ -326,6 +326,7 @@ namespace Orchard.Environment.Extensions
                                 {
                                     PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, locale);
                                     PopulateProbingFolder(assetResolvedPath, locale);
+                                    PopulateRuntimeFolder(assetResolvedPath, locale);
                                 }
                             }
                         }
@@ -373,6 +374,7 @@ namespace Orchard.Environment.Extensions
                                 {
                                     PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, asset.Culture);
                                     PopulateProbingFolder(assetResolvedPath, asset.Culture);
+                                    PopulateRuntimeFolder(assetResolvedPath, asset.Culture);
                                 }
                             }
                         }
@@ -421,6 +423,7 @@ namespace Orchard.Environment.Extensions
                             {
                                 PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, asset.Locale);
                                 PopulateProbingFolder(assetResolvedPath, asset.Locale);
+                                PopulateRuntimeFolder(assetResolvedPath, asset.Locale);
                             }
                         }
                     }
@@ -490,8 +493,7 @@ namespace Orchard.Environment.Extensions
 
         private bool IsAssemblyLoaded(string assemblyName)
         {
-            Lazy<Assembly> assembly;
-            return _loadedAssemblies.TryGetValue(assemblyName, out assembly);
+            return _loadedAssemblies.ContainsKey(assemblyName);
         }
 
         private Assembly LoadFromAssemblyPath(string assemblyPath)
@@ -571,6 +573,12 @@ namespace Orchard.Environment.Extensions
         private void PopulateProbingFolder(string assetPath, string relativeFolderPath = null)
         {
             PopulateBinaryFolder(_probingFolderPath, assetPath, relativeFolderPath);
+        }
+
+        private void PopulateRuntimeFolder(string assetPath, string relativeFolderPath = null)
+        {
+            var runtimeDirectory = Path.GetDirectoryName(CSharpExtensionCompiler.EntryAssembly.Location);
+            PopulateBinaryFolder(runtimeDirectory, assetPath, relativeFolderPath);
         }
     }
 }


### PR DESCRIPTION
The job was almost done because i heard that localization would use .resx resources files. So, after some tests, i just needed to also store resources assemblies files in the runtime directory. @sebastienros told me that localization will instead use *.po files. But the stuff is done and maybe we will need it. So let me know.

That said, there is the use case where a module uses a package which have resources assemblies files. Here, even we don't need to compile them, we still need to store them in probing folders and now in the runtime directory. So, after more thinking, maybe better to keep this stuff.

Note: Also a little change to use in 2 places the dictionnary `ContainsKey()` in place of `TryGetValue()`.

Best.