### PR TITLE
fix failing tests

### DIFF
--- a/test/Orchard.Tests/DisplayManagement/ShapeFactoryTests.cs
+++ b/test/Orchard.Tests/DisplayManagement/ShapeFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orchard.DisplayManagement;
+using Orchard.DisplayManagement.Theming;
 using Orchard.DisplayManagement.Descriptors;
 using Orchard.DisplayManagement.Implementation;
 using Orchard.DisplayManagement.Shapes;
@@ -21,6 +22,7 @@ namespace Orchard.Tests.DisplayManagement
             IServiceCollection serviceCollection = new ServiceCollection();
 
             serviceCollection.AddScoped<ILoggerFactory, StubLoggerFactory>();
+            serviceCollection.AddScoped<IThemeManager, ThemeManager>();
             serviceCollection.AddScoped<IShapeFactory, DefaultShapeFactory>();
             serviceCollection.AddScoped<IExtensionManager, StubExtensionManager>();
             serviceCollection.AddScoped<IShapeTableManager, TestShapeTableManager>();


### PR DESCRIPTION
This patch fixes the following ShapeFactorytests.

- ShapeHasAttributesType
- CreateShapeWithNamedArguments
- CallSyntax
- CallInitializer
- CallInitializerWithBaseType