### PR TITLE
Fix Composite Command Implementation and Test

### DIFF
--- a/src/Orchard.Environment.Commands/CommandHandlerDescriptorBuilder.cs
+++ b/src/Orchard.Environment.Commands/CommandHandlerDescriptorBuilder.cs
@@ -52,7 +52,7 @@ namespace Orchard.Environment.Commands
                 return attributes.Cast<CommandNameAttribute>().Single().Commands;
             }
 
-            return new[] { methodInfo.Name.Replace('_', ' ') };
+            return new[] { methodInfo.Name };
         }
     }
 }

--- a/test/Orchard.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
+++ b/test/Orchard.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
@@ -35,6 +35,7 @@ namespace Orchard.Tests.Commands
             {
             }
 
+            [CommandName("Foo Bar")]
             public void Foo_Bar()
             {
             }

--- a/test/Orchard.Tests/Commands/CommandManagerTests.cs
+++ b/test/Orchard.Tests/Commands/CommandManagerTests.cs
@@ -42,6 +42,7 @@ namespace Orchard.Tests.Commands
                 return "success!";
             }
 
+            [CommandName("Foo Bar")]
             public string Foo_Bar(string bleah)
             {
                 return bleah;


### PR DESCRIPTION
Summary of changes

- Remove a limitation that Command names can't have underscore in their names, underscore was replaced with space also adjust concerned test. [ change in File :  CommandHandlerDescriptorBuilder.cs ] 

- Don't iterate over all user provided command arguments while matching as we don't support executing multiple commands we only need the first one others are arguments to the command [ change in file :  DefaultCommandManager.cs ]

- Fix failing RunACompositeCommandTest test in CommandManagerTests.cs file by implementing/fixing composite commands [ change in file : DefaultCommandManager.cs ]