### PR TITLE
Little update of PermissionHandler.

### DIFF
--- a/src/Orchard.Security/AuthorizationHandlers/PermissionHandler.cs
+++ b/src/Orchard.Security/AuthorizationHandlers/PermissionHandler.cs
@@ -12,18 +12,18 @@ namespace Orchard.Security.AuthorizationHandlers
     [ScopedComponent(typeof(IAuthorizationHandler))]
     public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
     {
-        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
         {
             if (!(bool)context?.User?.Identity?.IsAuthenticated)
             {
-                await Task.CompletedTask;
+                return Task.CompletedTask;
             }
             else if (context.User.HasClaim(Permission.ClaimType, requirement.Permission.Name))
             {
                 context.Succeed(requirement);
             }
 
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION

**This PR**

- After viewing a recently published committee video and as mentioned by @sebastienros, so, check if it's still relevant.

**For infos**

- In the same video you was discussing about using one of these 2 lines

    ```
DefaultHandler = appBuilder.ApplicationServices.GetRequiredService<MvcRouteHandler>();
    DefaultHandler = serviceProvider.GetRequiredService<MvcRouteHandler>();
```
For infos, the original code was

    ```
    DefaultHandler = new MvcRouteHandler();`
```
But we can't use anymore `new MvcRouteHandler()` without any arguments. And now there is only one `MvcRouteHandler()` per app that you can request as a service.

- Not seen in depth so not sure it could concern us, but, for infos, they also talked about attribute routing where each route entry now has it's own handler (instance of `MvcAttributeRouteHandler`).

- You was also discussing about this line of code

    ```
    controller.RouteValues.Add("area", feature.Descriptor.Id);
```
For infos, the original code was

    ```
    controller.RouteConstraints.Add(new AreaAttribute(feature.Descriptor.Id));
```
But the ControllerModel doesn't have anymore a `RouteConstraints` collection, replaced with `RouteValues` which still means values that must be present.

Best.