### PR TITLE
Fix Orchard.OpenId to use a data protection provider derived from the DP registered in the DI container

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Orchard.OpenId.Models;
 using Orchard.OpenId.Services;
 using Orchard.OpenId.ViewModels;
 using Orchard.Users.Models;
@@ -32,18 +31,26 @@ namespace Orchard.OpenId.Controllers
             _userManager = userManager;
         }
 
-        [HttpPost]
+        [HttpPost, Produces("application/json")]
         public Task<IActionResult> Token()
         {
             var request = HttpContext.GetOpenIdConnectRequest();
 
             if (request.IsPasswordGrantType())
+            {
                 return ExchangePasswordGrantType(request);
+            }
             else if (request.IsClientCredentialsGrantType())
+            {
                 return ExchangeClientCredentialsGrantType(request);
+            }
             else
             {
-                return Task.FromResult(BadRequest() as IActionResult);
+                return Task.FromResult<IActionResult>(BadRequest(new OpenIdConnectResponse
+                {
+                    Error = OpenIdConnectConstants.Errors.UnsupportedResponseType,
+                    ErrorDescription = "The specified grant type is not supported."
+                }));
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Users/Module.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Module.cs
@@ -20,14 +20,14 @@ namespace Orchard.Users
         private readonly string _tenantName;
         private readonly string _tenantPrefix;
         private readonly IdentityOptions _options;
-        private readonly IDataProtector _dataProtector;
+        private readonly IDataProtectionProvider _dataProtectionProvider;
 
         public Startup(ShellSettings shellSettings, IOptions<IdentityOptions> options, IDataProtectionProvider dataProtectionProvider)
         {
             _options = options.Value;
             _tenantName = shellSettings.Name;
             _tenantPrefix = shellSettings.RequestUrlPrefix;
-            _dataProtector = dataProtectionProvider.CreateProtector(_tenantName);
+            _dataProtectionProvider = dataProtectionProvider.CreateProtector(_tenantName);
         }
 
         public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)
@@ -72,10 +72,10 @@ namespace Orchard.Users
                 options.Cookies.ApplicationCookie.CookiePath = _tenantPrefix;
                 options.Cookies.ApplicationCookie.LoginPath = new PathString("/Orchard.Users/Account/Login/");
                 options.Cookies.ApplicationCookie.AccessDeniedPath = new PathString("/Orchard.Users/Account/Login/");
-                options.Cookies.ApplicationCookie.DataProtectionProvider = _dataProtector;
-                options.Cookies.ExternalCookie.DataProtectionProvider = _dataProtector;
-                options.Cookies.TwoFactorRememberMeCookie.DataProtectionProvider = _dataProtector;
-                options.Cookies.TwoFactorUserIdCookie.DataProtectionProvider = _dataProtector;                
+                options.Cookies.ApplicationCookie.DataProtectionProvider = _dataProtectionProvider;
+                options.Cookies.ExternalCookie.DataProtectionProvider = _dataProtectionProvider;
+                options.Cookies.TwoFactorRememberMeCookie.DataProtectionProvider = _dataProtectionProvider;
+                options.Cookies.TwoFactorUserIdCookie.DataProtectionProvider = _dataProtectionProvider;                
             });
             
 


### PR DESCRIPTION
`DataProtectionProvider.Create(tenantName)` shouldn't be used as it prevents the end user from configuring the data protection options that will be ultimately used by OpenIddict to create new tokens. This PR fixes that by resolving `IDataProtectionProvider` from the DI container and by creating a sub-provider per tenant.

Note: I'm not able to test this PR as I can't make Orchard work on my machine so please don't merge it as-is: an exception is thrown from a logging extension (same as https://github.com/OrchardCMS/Orchard2/issues/203) and when commenting out this extension, all I get is 404 responses.

@sebastienros when you have a minute, please rebase the oauth2 branch, it's in a pretty bad state right now (expect a few conflicts 'cause you merged @jersiovic's PR without rebasing it properly first)