### PR TITLE
Prevent dynamic compilation of a module if precompiled by VS.

### DIFF
--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -210,10 +210,12 @@ namespace Orchard.Environment.Extensions.Compilers
                         }
                     }
                 }
-                // Check for an ambient library
+                // Check for a resolved but ambient library (compiled e.g by VS)
                 else if (library != null && AmbientLibraries.Contains(library.Identity.Name))
                 {
-                    references.AddRange(dependency.CompilationAssemblies.Select(r => Path.Combine(runtimeDirectory, r.FileName)));
+                    // Search in the regular project bin folder, fallback to the runtime directory
+                    references.AddRange(dependency.CompilationAssemblies.Select(r => File.Exists(r.ResolvedPath)
+                        ? r.ResolvedPath : Path.Combine(runtimeDirectory, r.FileName)));
                 }
                 else
                 {
@@ -317,7 +319,7 @@ namespace Orchard.Environment.Extensions.Compilers
                     var prevInputs = new HashSet<string>(File.ReadAllLines(rsp));
                     var newInputs = new HashSet<string>(allArgs);
 
-                    if (!prevInputs.Except(newInputs).Any() && ! newInputs.Except(prevInputs).Any())
+                    if (!prevInputs.Except(newInputs).Any() && !newInputs.Except(prevInputs).Any())
                     {
                         PrintMessage($"{context.ProjectName()}: Previously compiled, skipping dynamic compilation.");
                         return _compiledLibraries[context.ProjectName()] = true;


### PR DESCRIPTION
To see if we need to compile we check compilation IO and the previous context stored in `obj/**/dotnet-compile-csc.rsp` which contains compilation options and all compilation IO paths previously used.

Before, when building from VS, binaries was outputed to the `artifacts` folder while dynamic compilation references them from regular projects bin folders. So, dynamic compilations was done to re-generate these binaries, and compilation IO paths (and then the compilation context) was not the same.

Now it's ok, but for ambient projects, which are not dynamically compiled, the choice was to always reference their binaries from the runtime directory. So, to generate the same compilation context as VS, and because it's now possible, for ambient projects we also 1st try to use regular project bin folders.

This way, in a dev context, the `dotnet-compile-csc.rsp` file generated by VS or dynamic compilation is now the same. **So now, if a module is pre-built with VS, it is not dynamically re-compiled at runtime**.

Best
