### PR TITLE
React to design changes in OpenIddict

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OpenId/Startup.cs
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/Startup.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -11,8 +13,6 @@ using Orchard.OpenId.Services;
 using Orchard.Security;
 using Orchard.Settings;
 using Orchard.Users.Models;
-using System;
-using Microsoft.AspNetCore.DataProtection;
 
 namespace Orchard.OpenId
 {
@@ -55,14 +55,14 @@ namespace Orchard.OpenId
             });
         }
 
-        public override void ConfigureServices(IServiceCollection serviceCollection)
+        public override void ConfigureServices(IServiceCollection services)
         {
-            serviceCollection.AddScoped<OpenIdApplicationIndexProvider>();
-            serviceCollection.AddScoped<OpenIdTokenIndexProvider>();
-            serviceCollection.TryAddScoped<IOpenIdApplicationManager, OpenIdApplicationManager>();
-            serviceCollection.TryAddScoped<IOpenIdApplicationStore, OpenIdApplicationStore>();
+            services.AddScoped<OpenIdApplicationIndexProvider>();
+            services.AddScoped<OpenIdTokenIndexProvider>();
+            services.TryAddScoped<IOpenIdApplicationManager, OpenIdApplicationManager>();
+            services.TryAddScoped<IOpenIdApplicationStore, OpenIdApplicationStore>();
 
-            var builder = serviceCollection.AddOpenIddict<User, Role, OpenIdApplication, OpenIdAuthorization, OpenIdScope, OpenIdToken>()
+            var builder = services.AddOpenIddict<User, Role, OpenIdApplication, OpenIdAuthorization, OpenIdScope, OpenIdToken>()
                 .AddApplicationStore<OpenIdApplicationStore>()
                 .AddTokenStore<OpenIdTokenStore>()
                 .AddUserStore<OpenIdUserStore>()

--- a/src/Orchard.Web/Modules/Orchard.OpenId/project.json
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/project.json
@@ -1,14 +1,13 @@
 {
   "version": "2.0.0-*",
   "dependencies": {
+    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Orchard.ContentManagement.Display": "2.0.0-*",
     "Orchard.Data": "2.0.0-*",
-    "Orchard.Users": "2.0.0-*",
-    "OpenIddict": "1.0.0-alpha2-*",
-    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0",
-    "Microsoft.AspNetCore.DataProtection.Extensions": "1.0.0",
     "Orchard.Roles": "2.0.0-*",
+    "Orchard.Users": "2.0.0-*",
+    "OpenIddict": "1.0.0-alpha2-*"
   },
   "buildOptions": {
     "define": [ "TRACE" ],


### PR DESCRIPTION
I was recently asked to remove the internal lockout checks made by OpenIddict. Since it's no longer responsible of determining whether an account has been locked out or not, the `Orchard.OpenId` module must implement them if we want to support lockout.

This PR also references the new `OpenIddict.Mvc` package, that allows binding `OpenIdConnectRequest` instances without having to call `HttpContext.GetOpenIdConnectRequest()`.

Please don't merge this PR until I have a chance to test it.

/cc @sebastienros @jersiovic 