### PR TITLE
Precompiled Modules.

### DIFF
--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -223,7 +223,6 @@ namespace Orchard.Environment.Extensions.Compilers
                                 var path = Path.Combine(fallbackBinPath, relativeFolderPath, assetFileName);
                                 assetResolvedPath = File.Exists(path) ? path : null;
                             }
-
                         }
 
                         if (!String.IsNullOrEmpty(assetResolvedPath))

--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -152,26 +152,34 @@ namespace Orchard.Environment.Extensions.Compilers
                 // Check for an unresolved library
                 if (library != null && !library.Resolved)
                 {
-                    var fileName = GetAssemblyFileName(library.Identity.Name);
+                    var assetFileName = CompilerUtility.GetAssemblyFileName(library.Identity.Name);
 
                     // Search in the runtime directory
-                    var path = Path.Combine(runtimeDirectory, fileName);
+                    var assetResolvedPath = Path.Combine(runtimeDirectory, assetFileName);
 
-                    if (!File.Exists(path))
+                    if (!File.Exists(assetResolvedPath))
                     {
                         // Fallback to the project output path or probing folder
-                        path = ResolveAssetPath(outputPath, probingFolderPath, fileName);
+                        assetResolvedPath = ResolveAssetPath(outputPath, probingFolderPath, assetFileName);
+
+                        if (String.IsNullOrEmpty(assetResolvedPath))
+                        {
+                            // Fallback to this (possible) precompiled module bin folder
+                            var path = Path.Combine(Directory.GetParent(library.Path).FullName, Constants.BinDirectoryName, assetFileName);
+                            assetResolvedPath = File.Exists(path) ? path : null;
+                        }
                     }
 
-                    if (!String.IsNullOrEmpty(path))
+                    if (!String.IsNullOrEmpty(assetResolvedPath))
                     {
-                        references.Add(path);
+                        references.Add(assetResolvedPath);
                     }
                 }
                 // Check for an unresolved package
                 else if (package != null && !package.Resolved)
                 {
                     var runtimeAssets = new HashSet<string>(package.RuntimeAssemblies.Select(x => x.Path), StringComparer.OrdinalIgnoreCase);
+                    string fallbackBinPath = null;
 
                     foreach (var asset in package.CompileTimeAssemblies)
                     {
@@ -179,50 +187,75 @@ namespace Orchard.Environment.Extensions.Compilers
                         var isRuntimeAsset = runtimeAssets.Contains(asset.Path);
 
                         // Search in the runtime directory
-                        var path = isRuntimeAsset ? Path.Combine(runtimeDirectory, assetFileName)
-                            : Path.Combine(runtimeDirectory, CompilerUtility.RefsDirectoryName, assetFileName);
+                        var relativeFolderPath = isRuntimeAsset ? String.Empty : CompilerUtility.RefsDirectoryName;
+                        var assetResolvedPath = Path.Combine(runtimeDirectory, relativeFolderPath, assetFileName);
 
-                        if (!File.Exists(path))
+                        if (!File.Exists(assetResolvedPath))
                         {
                             // Fallback to the project output path or probing folder
-                            var relativeFolderPath = isRuntimeAsset ? String.Empty : CompilerUtility.RefsDirectoryName;
-                            path = ResolveAssetPath(outputPath, probingFolderPath, assetFileName, relativeFolderPath);
+                            assetResolvedPath = ResolveAssetPath(outputPath, probingFolderPath, assetFileName, relativeFolderPath);
                         }
 
-                        if (!String.IsNullOrEmpty(path))
+                        if (String.IsNullOrEmpty(assetResolvedPath))
                         {
-                            references.Add(path);
+                            if (fallbackBinPath == null)
+                            {
+                                fallbackBinPath = String.Empty;
+
+                                // Fallback to a (possible) parent precompiled module bin folder
+                                var parentBinPaths = CompilerUtility.GetOtherParentProjectsLocations(context, package)
+                                    .Select(x => Path.Combine(x, Constants.BinDirectoryName));
+
+                                foreach (var binaryPath in parentBinPaths)
+                                {
+                                    var path = Path.Combine(binaryPath, relativeFolderPath, assetFileName);
+
+                                    if (File.Exists(path))
+                                    {
+                                        assetResolvedPath = path;
+                                        fallbackBinPath = binaryPath;
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (!String.IsNullOrEmpty(fallbackBinPath))
+                            {
+                                var path = Path.Combine(fallbackBinPath, relativeFolderPath, assetFileName);
+                                assetResolvedPath = File.Exists(path) ? path : null;
+                            }
+
+                        }
+
+                        if (!String.IsNullOrEmpty(assetResolvedPath))
+                        {
+                            references.Add(assetResolvedPath);
                         }
                     }
                 }
                 // Check for a precompiled library
                 else if (library != null && !dependency.CompilationAssemblies.Any())
                 {
-                    var projectContext = GetProjectContextFromPath(library.Project.ProjectDirectory);
+                    // Search in the project output path or probing folder
+                    var assetFileName = CompilerUtility.GetAssemblyFileName(library.Identity.Name);
+                    var assetResolvedPath = ResolveAssetPath(outputPath, probingFolderPath, assetFileName);
 
-                    if (projectContext != null)
+                    if (String.IsNullOrEmpty(assetResolvedPath))
                     {
-                        var fileName = GetAssemblyFileName(library.Identity.Name);
+                        // Fallback to this precompiled project output path
+                        var path = Path.Combine(CompilerUtility.GetAssemblyFolderPath(library.Project.ProjectDirectory,
+                            config, context.TargetFramework.DotNetFrameworkName), assetFileName);
+                        assetResolvedPath = File.Exists(path) ? path : null;
+                    }
 
-                        // Search in the precompiled project output path
-                        var path = Path.Combine(projectContext.GetOutputPaths(config).CompilationOutputPath, fileName);
-
-                        if (!File.Exists(path))
-                        {
-                            // Fallback to this project output path or probing folder
-                            path = ResolveAssetPath(outputPath, probingFolderPath, fileName);
-                        }
-
-                        if (!String.IsNullOrEmpty(path))
-                        {
-                            references.Add(path);
-                        }
+                    if (!String.IsNullOrEmpty(assetResolvedPath))
+                    {
+                        references.Add(assetResolvedPath);
                     }
                 }
                 // Check for a resolved but ambient library (compiled e.g by VS)
                 else if (library != null && AmbientLibraries.Contains(library.Identity.Name))
                 {
-                    // Search in the regular project bin folder, fallback to the runtime directory
+                    // Search in the regular project output path, fallback to the runtime directory
                     references.AddRange(dependency.CompilationAssemblies.Select(r => File.Exists(r.ResolvedPath)
                         ? r.ResolvedPath : Path.Combine(runtimeDirectory, r.FileName)));
                 }
@@ -385,7 +418,7 @@ namespace Orchard.Environment.Extensions.Compilers
             }
 
             // Locate csc.dll and the csc.exe asset
-            var cscDllPath = Path.Combine(runtimeDirectory, GetAssemblyFileName("csc"));
+            var cscDllPath = Path.Combine(runtimeDirectory, CompilerUtility.GetAssemblyFileName("csc"));
 
             // Search in the runtime directory
             var cscRelativePath = Path.Combine("runtimes", "any", "native", "csc.exe");
@@ -470,11 +503,6 @@ namespace Orchard.Environment.Extensions.Compilers
         private ProjectContext GetProjectContextFromPath(string projectPath)
         {
             return ProjectContext.CreateContextForEachFramework(projectPath).FirstOrDefault();
-        }
-
-        private string GetAssemblyFileName(string assemblyName)
-        {
-            return assemblyName + FileNameSuffixes.DotNet.DynamicLib;
         }
 
         private string ResolveAssetPath(string binaryFolderPath, string probingFolderPath,  string assetFileName, string relativeFolderPath = null)

--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -641,15 +641,16 @@ namespace Orchard.Environment.Extensions.Compilers
                 commonArgs.Add("-t:library");
             }
 
+            // Here, force debugType to portable
             if (string.IsNullOrEmpty(options.DebugType))
             {
-                commonArgs.Add(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                commonArgs.Add(false /*RuntimeInformation.IsOSPlatform(OSPlatform.Windows)*/
                     ? "-debug:full"
                     : "-debug:portable");
             }
             else
             {
-                commonArgs.Add(options.DebugType == "portable"
+                commonArgs.Add(true /*options.DebugType == "portable"*/
                     ? "-debug:portable"
                     : "-debug:full");
             }

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -453,7 +453,7 @@ namespace Orchard.Environment.Extensions
                                 var locale = Directory.GetParent(asset).Name
                                     .Replace(assetFolderName, String.Empty)
                                     .Replace(assemblyFolderName, String.Empty)
-                                    .Replace(ProbingDirectoryName, String.Empty);
+                                    .Replace(_probingDirectoryName, String.Empty);
 
                                 PopulateBinaryFolder(assemblyFolderPath, asset, locale);
                                 PopulateProbingFolder(asset, locale);

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -127,7 +127,6 @@ namespace Orchard.Environment.Extensions
             }
             else
             {
-
                 LoadPrecompiledModule(descriptor);
             }
 

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Compiler.Common;
@@ -509,8 +508,8 @@ namespace Orchard.Environment.Extensions
 
         internal void LoadPrecompiledModule(ExtensionDescriptor descriptor)
         {
-            var extensionPath = Path.Combine(_fileSystem.RootPath, descriptor.Location, descriptor.Id);
-            var assemblyFolderPath = Path.Combine(extensionPath, Constants.BinDirectoryName);
+            var fileInfo = _hostingEnvironment.GetExtensionFileInfo(descriptor);
+            var assemblyFolderPath = Path.Combine(fileInfo.PhysicalPath, Constants.BinDirectoryName);
             var assemblyPath = Path.Combine(assemblyFolderPath, CompilerUtility.GetAssemblyFileName(descriptor.Id));
 
             // default runtime assemblies: "bin/{assembly}.dll"

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Compiler.Common;
@@ -6,11 +7,12 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Compilation;
+using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.DotNet.Tools.Common;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NuGet.Frameworks;
+using NuGet.Packaging;
 using Orchard.Environment.Extensions.Compilers;
 using Orchard.Environment.Extensions.FileSystem;
 using Orchard.Environment.Extensions.Models;
@@ -109,7 +111,7 @@ namespace Orchard.Environment.Extensions
 
             var projectContext = GetProjectContext(descriptor);
 
-            if (projectContext == null || IsDynamicContext(projectContext))
+            if (!IsPrecompiledContext(projectContext))
             {
                 return null;
             }
@@ -119,7 +121,17 @@ namespace Orchard.Environment.Extensions
                 return _loadedAssemblies[descriptor.Id].Value;
             }
 
-            return LoadProject(projectContext);
+            if (projectContext != null)
+            {
+                LoadProject(projectContext);
+            }
+            else
+            {
+
+                LoadPrecompiledModule(descriptor);
+            }
+
+            return IsAssemblyLoaded(descriptor.Id) ? _loadedAssemblies[descriptor.Id].Value : null;
         }
 
         public Assembly LoadDynamicExtension(ExtensionDescriptor descriptor)
@@ -131,7 +143,7 @@ namespace Orchard.Environment.Extensions
 
             var projectContext = GetProjectContext(descriptor);
 
-            if (projectContext == null || !IsDynamicContext(projectContext))
+            if (!IsDynamicContext(projectContext))
             {
                 return null;
             }
@@ -142,8 +154,9 @@ namespace Orchard.Environment.Extensions
             }
 
             CompileProject(projectContext);
+            LoadProject(projectContext);
 
-            return LoadProject(projectContext);
+            return IsAssemblyLoaded(descriptor.Id) ? _loadedAssemblies[descriptor.Id].Value : null;
         }
 
         internal ProjectContext GetProjectContext(ExtensionDescriptor descriptor)
@@ -156,7 +169,10 @@ namespace Orchard.Environment.Extensions
 
         internal ProjectContext GetProjectContextFromPath(string projectPath)
         {
-            return ProjectContext.CreateContextForEachFramework(projectPath).FirstOrDefault();
+            return File.Exists(Path.Combine(projectPath, Project.FileName))
+                && File.Exists(Path.Combine(projectPath, LockFile.FileName))
+                ? ProjectContext.CreateContextForEachFramework(projectPath).FirstOrDefault()
+                : null;
         }
 
         internal void CompileProject(ProjectContext context)
@@ -199,17 +215,13 @@ namespace Orchard.Environment.Extensions
             }
         }
 
-        internal Assembly LoadProject(ProjectContext context)
+        internal void LoadProject(ProjectContext context)
         {
             var outputPaths = context.GetOutputPaths(Configuration);
             var assemblyPath = outputPaths.CompilationFiles.Assembly;
-
-            var assembly = LoadFromAssemblyPath(assemblyPath);
-            PopulateProbingFolder(assemblyPath);
-
             var assemblyFolderPath = outputPaths.CompilationOutputPath;
-            var libraryExporter = context.CreateExporter(Configuration);
 
+            var libraryExporter = context.CreateExporter(Configuration);
             var runtimeIds = GetRuntimeIdentifiers();
 
             foreach (var dependency in libraryExporter.GetAllExports())
@@ -222,8 +234,15 @@ namespace Orchard.Environment.Extensions
                 {
                     if (!IsAmbientAssembly(library.Identity.Name))
                     {
-                        var assetFileName = GetAssemblyFileName(library.Identity.Name);
+                        var assetFileName = CompilerUtility.GetAssemblyFileName(library.Identity.Name);
                         var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName);
+
+                        if (String.IsNullOrEmpty(assetResolvedPath))
+                        {
+                            // Fallback to this (possible) precompiled module bin folder
+                            var path = Path.Combine(Directory.GetParent(library.Path).FullName, Constants.BinDirectoryName, assetFileName);
+                            assetResolvedPath = File.Exists(path) ? path : null;
+                        }
 
                         if (!String.IsNullOrEmpty(assetResolvedPath))
                         {
@@ -234,12 +253,18 @@ namespace Orchard.Environment.Extensions
                             var resourceFileName = library.Identity.Name + ".resources.dll";
                             var assemblyFolderName = PathUtility.GetDirectoryName(assemblyFolderPath);
 
-                            var resourceAssemblies = Directory.GetFiles(assemblyFolderPath, resourceFileName, SearchOption.AllDirectories)
+                            var assetFolder = Directory.GetParent(assetResolvedPath);
+                            var assetFolderName = PathUtility.GetDirectoryName(assetFolder.FullName);
+                            var assetFolderPath = assetFolder.FullName;
+
+                            var resourceAssemblies = Directory.GetFiles(assetFolderPath, resourceFileName, SearchOption.AllDirectories)
+                                .Union(Directory.GetFiles(assemblyFolderPath, resourceFileName, SearchOption.AllDirectories))
                                 .Union(Directory.GetFiles(_probingFolderPath, resourceFileName, SearchOption.AllDirectories));
 
                             foreach (var asset in resourceAssemblies)
                             {
                                 var locale = Directory.GetParent(asset).Name
+                                    .Replace(assetFolderName, String.Empty)
                                     .Replace(assemblyFolderName, String.Empty)
                                     .Replace(_probingDirectoryName, String.Empty);
 
@@ -253,6 +278,8 @@ namespace Orchard.Environment.Extensions
                 // Check for an unresolved package
                 else if (package != null && !package.Resolved)
                 {
+                    string fallbackBinPath = null;
+
                     foreach (var asset in package.RuntimeAssemblies)
                     {
                         var assetName = Path.GetFileNameWithoutExtension(asset.Path);
@@ -261,6 +288,35 @@ namespace Orchard.Environment.Extensions
                         {
                             var assetFileName = Path.GetFileName(asset.Path);
                             var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName);
+
+                            if (String.IsNullOrEmpty(assetResolvedPath))
+                            {
+                                if (fallbackBinPath == null)
+                                {
+                                    fallbackBinPath = String.Empty;
+
+                                    // Fallback to a (possible) parent precompiled module bin folder
+                                    var parentBinPaths = CompilerUtility.GetOtherParentProjectsLocations(context, package)
+                                        .Select(x => Path.Combine(x, Constants.BinDirectoryName));
+
+                                    foreach (var binaryPath in parentBinPaths)
+                                    {
+                                        var path = Path.Combine(binaryPath, assetFileName);
+
+                                        if (File.Exists(path))
+                                        {
+                                            assetResolvedPath = path;
+                                            fallbackBinPath = binaryPath;
+                                            break;
+                                        }
+                                    }
+                                }
+                                else if (!String.IsNullOrEmpty(fallbackBinPath))
+                                {
+                                    var path = Path.Combine(fallbackBinPath, assetFileName);
+                                    assetResolvedPath = File.Exists(path) ? path : null;
+                                }
+                            }
 
                             if (!String.IsNullOrEmpty(assetResolvedPath))
                             {
@@ -283,6 +339,12 @@ namespace Orchard.Environment.Extensions
                                 ? Path.GetDirectoryName(asset.Path) : String.Empty;
 
                             var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, relativeFolderPath);
+
+                            if (String.IsNullOrEmpty(assetResolvedPath) && !String.IsNullOrEmpty(fallbackBinPath))
+                            {
+                                var path = Path.Combine(fallbackBinPath, relativeFolderPath, assetFileName);
+                                assetResolvedPath = File.Exists(path) ? path : null;
+                            }
 
                             if (!String.IsNullOrEmpty(assetResolvedPath))
                             {
@@ -307,6 +369,12 @@ namespace Orchard.Environment.Extensions
                         {
                             var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, CompilerUtility.RefsDirectoryName);
 
+                            if (String.IsNullOrEmpty(assetResolvedPath) && !String.IsNullOrEmpty(fallbackBinPath))
+                            {
+                                var path = Path.Combine(fallbackBinPath, CompilerUtility.RefsDirectoryName, assetFileName);
+                                assetResolvedPath = File.Exists(path) ? path : null;
+                            }
+
                             if (!String.IsNullOrEmpty(assetResolvedPath))
                             {
                                 PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, CompilerUtility.RefsDirectoryName);
@@ -325,6 +393,12 @@ namespace Orchard.Environment.Extensions
                                 var assetFileName = Path.GetFileName(asset.Path);
                                 var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, locale);
 
+                                if (String.IsNullOrEmpty(assetResolvedPath) && !String.IsNullOrEmpty(fallbackBinPath))
+                                {
+                                    var path = Path.Combine(fallbackBinPath, locale, assetFileName);
+                                    assetResolvedPath = File.Exists(path) ? path : null;
+                                }
+
                                 if (!String.IsNullOrEmpty(assetResolvedPath))
                                 {
                                     PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, locale);
@@ -340,45 +414,45 @@ namespace Orchard.Environment.Extensions
                 {
                     if (!IsAmbientAssembly(library.Identity.Name))
                     {
-                        var projectContext = GetProjectContextFromPath(library.Project.ProjectDirectory);
+                        var assetFileName = CompilerUtility.GetAssemblyFileName(library.Identity.Name);
+                        var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName);
 
-                        if (projectContext != null)
+                        if (String.IsNullOrEmpty(assetResolvedPath))
                         {
-                            var assetFileName = GetAssemblyFileName(library.Identity.Name);
-                            var outputPath = projectContext.GetOutputPaths(Configuration).CompilationOutputPath;
-                            var assetResolvedPath = Path.Combine(outputPath, assetFileName);
+                            // Fallback to this precompiled project output path
+                            var outputPath = CompilerUtility.GetAssemblyFolderPath(library.Project.ProjectDirectory,
+                                Configuration, context.TargetFramework.DotNetFrameworkName);
+                            var path = Path.Combine(outputPath, assetFileName);
+                            assetResolvedPath = File.Exists(path) ? path : null;
+                        }
 
-                            if (!File.Exists(assetResolvedPath))
-                            {
-                                assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName);
-                            }
+                        if (!String.IsNullOrEmpty(assetResolvedPath))
+                        {
+                            LoadFromAssemblyPath(assetResolvedPath);
+                            PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath);
+                            PopulateProbingFolder(assetResolvedPath);
 
-                            if (!String.IsNullOrEmpty(assetResolvedPath))
-                            {
-                                LoadFromAssemblyPath(assetResolvedPath);
-                                PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath);
-                                PopulateProbingFolder(assetResolvedPath);
-                            }
+                            var resourceFileName = library.Identity.Name + ".resources.dll";
+                            var assemblyFolderName = PathUtility.GetDirectoryName(assemblyFolderPath);
 
-                            var compilationOptions = projectContext.ResolveCompilationOptions(Configuration);
-                            var resourceAssemblies = CompilerUtility.GetCultureResources(projectContext.ProjectFile, outputPath, compilationOptions);
+                            var assetFolder = Directory.GetParent(assetResolvedPath);
+                            var assetFolderName = PathUtility.GetDirectoryName(assetFolder.FullName);
+                            var assetFolderPath = assetFolder.FullName;
+
+                            var resourceAssemblies = Directory.GetFiles(assetFolderPath, resourceFileName, SearchOption.AllDirectories)
+                                .Union(Directory.GetFiles(assemblyFolderPath, resourceFileName, SearchOption.AllDirectories))
+                                .Union(Directory.GetFiles(_probingFolderPath, resourceFileName, SearchOption.AllDirectories));
 
                             foreach (var asset in resourceAssemblies)
                             {
-                                assetFileName = Path.GetFileName(asset.OutputFile);
-                                assetResolvedPath = asset.OutputFile;
+                                var locale = Directory.GetParent(asset).Name
+                                    .Replace(assetFolderName, String.Empty)
+                                    .Replace(assemblyFolderName, String.Empty)
+                                    .Replace(ProbingDirectoryName, String.Empty);
 
-                                if (!File.Exists(assetResolvedPath))
-                                {
-                                    assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, asset.Culture);
-                                }
-
-                                if (!String.IsNullOrEmpty(assetResolvedPath))
-                                {
-                                    PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, asset.Culture);
-                                    PopulateProbingFolder(assetResolvedPath, asset.Culture);
-                                    PopulateRuntimeFolder(assetResolvedPath, asset.Culture);
-                                }
+                                PopulateBinaryFolder(assemblyFolderPath, asset, locale);
+                                PopulateProbingFolder(asset, locale);
+                                PopulateRuntimeFolder(asset, locale);
                             }
                         }
                     }
@@ -432,8 +506,100 @@ namespace Orchard.Environment.Extensions
                     }
                 }
             }
+        }
 
-            return assembly;
+        internal void LoadPrecompiledModule(ExtensionDescriptor descriptor)
+        {
+            var extensionPath = Path.Combine(_fileSystem.RootPath, descriptor.Location, descriptor.Id);
+            var assemblyFolderPath = Path.Combine(extensionPath, Constants.BinDirectoryName);
+            var assemblyPath = Path.Combine(assemblyFolderPath, CompilerUtility.GetAssemblyFileName(descriptor.Id));
+
+            // default runtime assemblies: "bin/{assembly}.dll"
+            var runtimeAssemblies = Directory.GetFiles(assemblyFolderPath,
+                "*" + FileNameSuffixes.DotNet.DynamicLib, SearchOption.TopDirectoryOnly);
+
+            foreach (var asset in runtimeAssemblies)
+            {
+                var assetName = Path.GetFileNameWithoutExtension(asset);
+
+                if (!IsAmbientAssembly(assetName))
+                {
+                    var assetFileName = Path.GetFileName(asset);
+                    var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName);
+                    LoadFromAssemblyPath(assetResolvedPath);
+
+                    PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath);
+                    PopulateProbingFolder(assetResolvedPath);
+                }
+            }
+
+            // compile only assemblies: "bin/refs/{assembly}.dll"
+            if (Directory.Exists(Path.Combine(assemblyFolderPath, CompilerUtility.RefsDirectoryName)))
+            {
+                var compilationAssemblies = Directory.GetFiles(
+                    Path.Combine(assemblyFolderPath, CompilerUtility.RefsDirectoryName),
+                    "*" + FileNameSuffixes.DotNet.DynamicLib, SearchOption.TopDirectoryOnly);
+
+                foreach (var asset in compilationAssemblies)
+                {
+                    var assetFileName = Path.GetFileName(asset);
+                    var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, CompilerUtility.RefsDirectoryName);
+
+                    PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, CompilerUtility.RefsDirectoryName);
+                    PopulateProbingFolder(assetResolvedPath, CompilerUtility.RefsDirectoryName);
+                }
+            }
+
+            // specific runtime assemblies: "bin/runtimes/{rid}/lib/{tfm}/{assembly}.dll"
+            if (Directory.Exists(Path.Combine(assemblyFolderPath, PackagingConstants.Folders.Runtimes)))
+            {
+                var runtimeIds = GetRuntimeIdentifiers();
+
+                var runtimeTargets = Directory.GetFiles(
+                    Path.Combine(assemblyFolderPath, PackagingConstants.Folders.Runtimes),
+                    "*" + FileNameSuffixes.DotNet.DynamicLib, SearchOption.AllDirectories);
+
+                foreach (var asset in runtimeTargets)
+                {
+                    var assetName = Path.GetFileNameWithoutExtension(asset);
+
+                    if (!IsAmbientAssembly(assetName))
+                    {
+                        var tfmFolder = Directory.GetParent(asset);
+                        var libFolder = Directory.GetParent(tfmFolder.FullName);
+
+                        if (String.Equals(libFolder.Name, PackagingConstants.Folders.Lib, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var runtime = Directory.GetParent(libFolder.FullName).Name;
+                            var relativeFolderPath = Path.Combine(PackagingConstants.Folders.Runtimes, runtime, libFolder.Name, tfmFolder.Name);
+
+                            if (runtimeIds.Contains(runtime))
+                            {
+                                LoadFromAssemblyPath(asset);
+                            }
+
+                            PopulateProbingFolder(asset, relativeFolderPath);
+                        }
+                    }
+                }
+            }
+
+            // resource assemblies: "bin/{locale?}/{assembly}.resources.dll"
+            var resourceAssemblies = Directory.GetFiles(assemblyFolderPath, "*.resources"
+                + FileNameSuffixes.DotNet.DynamicLib, SearchOption.AllDirectories);
+
+            var assemblyFolderName = PathUtility.GetDirectoryName(assemblyFolderPath);
+
+            foreach (var asset in resourceAssemblies)
+            {
+                var assetFileName = Path.GetFileName(asset);
+                var locale = Directory.GetParent(asset).Name.Replace(assemblyFolderName, String.Empty);
+                var assetResolvedPath = ResolveAssemblyPath(assemblyFolderPath, assetFileName, locale);
+
+                PopulateBinaryFolder(assemblyFolderPath, assetResolvedPath, locale);
+                PopulateProbingFolder(assetResolvedPath, locale);
+                PopulateRuntimeFolder(assetResolvedPath, locale);
+            }
         }
 
         private static string GetConfiguration()
@@ -480,13 +646,18 @@ namespace Orchard.Environment.Extensions
 
         private bool IsDynamicContext (ProjectContext context)
         {
+            if (context == null)
+            {
+                return false;
+            }
+
             var compilationOptions = context.ResolveCompilationOptions(Configuration);
             return CompilerUtility.GetCompilationSources(context, compilationOptions).Any();
         }
 
         private bool IsPrecompiledContext (ProjectContext context)
         {
-            return !IsDynamicContext(context);
+            return context == null || !IsDynamicContext(context);
         }
 
         private bool IsAmbientAssembly(string assemblyName)
@@ -506,17 +677,6 @@ namespace Orchard.Environment.Extensions
                 {
                     return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
                 })).Value;
-        }
-
-        private string GetAssemblyFileName(string assemblyName)
-        {
-            return assemblyName + FileNameSuffixes.DotNet.DynamicLib;
-        }
-
-        private string GetAssemblyFolderPath(string rootPath, string framework)
-        {
-            return Path.Combine(rootPath, Constants.BinDirectoryName, Configuration,
-                NuGetFramework.Parse(framework).GetShortFolderName());
         }
 
         private string ResolveAssemblyPath(string binaryFolderPath, string assemblyName, string relativeFolderPath = null)

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -1,5 +1,11 @@
-﻿using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.ApplicationParts;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
@@ -16,13 +22,6 @@ using Orchard.Environment.Extensions.Compilers;
 using Orchard.Environment.Extensions.FileSystem;
 using Orchard.Environment.Extensions.Models;
 using Orchard.Localization;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
 
 namespace Orchard.Environment.Extensions
 {
@@ -38,19 +37,16 @@ namespace Orchard.Environment.Extensions
         private static readonly ConcurrentDictionary<string, Lazy<Assembly>> _loadedAssemblies = new ConcurrentDictionary<string, Lazy<Assembly>>(StringComparer.OrdinalIgnoreCase);
 
         private readonly Lazy<List<MetadataReference>> _metadataReferences;
-        private readonly ApplicationPartManager _applicationPartManager;
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly string _probingFolderPath;
         private readonly ILogger _logger;
 
         public ExtensionLibraryService(
-            ApplicationPartManager applicationPartManager,
             IHostingEnvironment hostingEnvironment,
             IOptions<ExtensionProbingOptions> optionsAccessor,
             ILogger<ExtensionLibraryService> logger)
         {
             _metadataReferences = new Lazy<List<MetadataReference>>(GetMetadataReferences);
-            _applicationPartManager = applicationPartManager;
             _hostingEnvironment = hostingEnvironment;
             _probingDirectoryName = optionsAccessor.Value.DependencyProbingDirectoryName;
             _probingFolderPath = _hostingEnvironment.ContentRootFileProvider.GetFileInfo(Path.Combine(optionsAccessor.Value.RootProbingName, _probingDirectoryName)).PhysicalPath;


### PR DESCRIPTION
First work on Precompiled Modules.

- A kind of Precompiled Project was already implemented when there is no source files but all binaries in the regular output path `bin/Debug/netcoreapp1.0`, and still the 2 project json files. So, we don't compile it but we can still use the Project Model to load the project.

- Here we can load a Precompiled Module which has no project json files but all needed assemblies directly in its `/bin` folder. Right now, we assume that all binaries are stored in the same structured way as done  by a dynamic compilation in `bin/Debug/netcoreapp1.0` (inspired from `dotnet publish`).

- This means e.g that specific runtime assemblies, with different implementations for different runtimes environments, are stored like this `bin/runtimes/{rid}/lib/{tfm}/{assembly}.dll`. I didn't see any modules using such assemblies (unless if already ambient) but we would need this.

- Already tested for 2 Precompiled Modules but, because of the dependency graph on different kinds of projects, there are many scenarios. At least i will test it when all modules are precompiled.

I'll continue the wiki page to provide enough details, then i'll ask here some questions.

**Update**: Just tried with all modules / themes as "Precompiled Modules", seems to work. So, here 1st question about the packaging process which is intended to produce a precompiled module.

> The packaging process will handle that, right now I will do it manually.

Do you mean a kind of `dotnet pack` but which will not output specific assets (as in the above example). As far as i have seen, a package doesn't embed its dependencies but provide a `.nuspec` file to reference them. And to use it, i need to reference it in `project.json` and doing a `dotnet restore`. So, right now, it's not clear for me how we can use modules as nuget packages.

 Or maybe you mean something we have to handle by code? A custom packaging and a `Dynamic Restoring`?

Best.