### PR TITLE
Use ApplicationCanDisplayErrors = true to allow AccessController to handle OpenID Connect error responses

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
@@ -166,8 +166,18 @@ namespace Orchard.OpenId.Controllers
 
         [HttpGet]
         public async Task<IActionResult> Authorize(
-            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectRequest request)
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectRequest request,
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectResponse response)
         {
+            if (response != null)
+            {
+                return View("Error", new ErrorViewModel
+                {
+                    Error = response.Error,
+                    ErrorDescription = response.ErrorDescription
+                });
+            }
+
             var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
             if (application == null)
             {
@@ -193,10 +203,20 @@ namespace Orchard.OpenId.Controllers
 
         [ActionName(nameof(Authorize))]
         [HttpPost, FormValueRequired("submit.Accept")]
-        public Task<IActionResult> Accept(
-            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectRequest request)
+        public async Task<IActionResult> Accept(
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectRequest request,
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectResponse response)
         {
-            return IssueAccessIdentityTokens(request);
+            if (response != null)
+            {
+                return View("Error", new ErrorViewModel
+                {
+                    Error = response.Error,
+                    ErrorDescription = response.ErrorDescription
+                });
+            }
+
+            return await IssueAccessIdentityTokens(request);
         }
 
         private async Task<IActionResult> IssueAccessIdentityTokens(OpenIdConnectRequest request)
@@ -231,16 +251,36 @@ namespace Orchard.OpenId.Controllers
 
         [ActionName(nameof(Authorize))]
         [HttpPost, FormValueRequired("submit.Deny")]
-        public IActionResult Deny()
+        public IActionResult Deny(
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectResponse response)
         {
+            if (response != null)
+            {
+                return View("Error", new ErrorViewModel
+                {
+                    Error = response.Error,
+                    ErrorDescription = response.ErrorDescription
+                });
+            }
+
             // Notify OpenIddict that the authorization grant has been denied by the resource owner
             // to redirect the user agent to the client application using the appropriate response_mode.
             return Forbid(OpenIdConnectServerDefaults.AuthenticationScheme);
         }
 
         [AllowAnonymous, HttpGet]
-        public async Task<IActionResult> Logout()
+        public async Task<IActionResult> Logout(
+            [ModelBinder(BinderType = typeof(OpenIddictModelBinder))] OpenIdConnectResponse response)
         {
+            if (response != null)
+            {
+                return View("Error", new ErrorViewModel
+                {
+                    Error = response.Error,
+                    ErrorDescription = response.ErrorDescription
+                });
+            }
+
             await _signInManager.SignOutAsync();
 
             // Returning a SignOutResult will ask OpenIddict to redirect the user agent

--- a/src/Orchard.Web/Modules/Orchard.OpenId/Startup.cs
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/Startup.cs
@@ -87,7 +87,11 @@ namespace Orchard.OpenId
                 .AllowRefreshTokenFlow()
 
                 .UseDataProtectionProvider(_dataProtectionProvider)
-                .UseJsonWebTokens();
+                .UseJsonWebTokens()
+
+                // Use the advanced ApplicationCanDisplayErrors = true option to allow AccessController
+                // to handle OpenID Connect error responses and render them in a custom error view.
+                .Configure(options => options.ApplicationCanDisplayErrors = true);
 
 #if DEBUG
             builder.DisableHttpsRequirement()


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/6998306/19219822/bbc2468e-8e1d-11e6-8e48-ca5b95772893.png)

After:

![image](https://cloud.githubusercontent.com/assets/6998306/19219814/a1ca79ea-8e1d-11e6-856b-c701155774fc.png)

@sebastienros please don't rebase the `oauth2` branch on top of `master` as it's currently broken for me:

```
Orchard.OrchardException: Shape type Layout not found
   at Orchard.DisplayManagement.Implementation.DisplayHelper.TryInvoke(InvokeBinder binder, Object[] args, Object& result) in C:\Users\Chalet Kévin\Documents\GitHub\Orchard2\src\Orchard.DisplayManagement\Implementation\DisplayHelper.cs:line 40
   at CallSite.Target(Closure , CallSite , Object , Object )
   at CallSite.Target(Closure , CallSite , Object , Object )
   at Orchard.DisplayManagement.Razor.RazorPage`1.Display(Object shape) in C:\Users\Chalet Kévin\Documents\GitHub\Orchard2\src\Orchard.DisplayManagement\Razor\RazorPage.cs:line 76
   at CallSite.Target(Closure , CallSite , _Views_Shared__Layout_cshtml , Object )
   at AspNetCore._Views_Shared__Layout_cshtml.<ExecuteAsync>d__21.MoveNext() in /Views/Shared/_Layout.cshtml:line 7
```