### PR TITLE
#280 Added support for multiple folders for modules

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ConfigurationExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Orchard.Hosting.Extensions
+{
+    public static class ConfigurationExtensions
+    {
+        public static IEnumerable<string> GetConfigurationArray(this IConfiguration configuration, string key)
+        {
+            if (configuration != null)
+            {
+                int index = 0;
+                string extraModuleFolder = configuration[key + ":" + index];
+                while (extraModuleFolder != null)
+                {
+                    yield return extraModuleFolder;
+                    index++;
+                    extraModuleFolder = configuration[key + ":" + index];
+                }
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Mvc/Razor/ModuleViewLocationExpander.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Mvc/Razor/ModuleViewLocationExpander.cs
@@ -1,10 +1,25 @@
 ﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Razor;
+using System.IO;
+using System.Linq;
 
 namespace Orchard.Hosting.Mvc.Razor
 {
     public class ModuleViewLocationExpander : IViewLocationExpander
     {
+        private readonly IDictionary<string,string> _moduleFolderPerAreaName;
+        public ModuleViewLocationExpander(IEnumerable<string> extraModulesFolders)
+        {
+            _moduleFolderPerAreaName = extraModulesFolders.Union(new List<string>() { "Modules" })
+                               .SelectMany(folder => Directory.GetDirectories(folder)
+                                    .Select(subfolder => 
+                                            new
+                                            {
+                                                ModuleFolder = folder,
+                                                AreaName = Path.GetFileName(subfolder)
+                                            } ))
+                                    .ToDictionary(area=>area.AreaName,area=>area.ModuleFolder);            
+        }
         /// <inheritdoc />
         public void PopulateValues(ViewLocationExpanderContext context)
         {
@@ -15,9 +30,9 @@ namespace Orchard.Hosting.Mvc.Razor
                                                                IEnumerable<string> viewLocations)
         {
             var result = new List<string>();
-
-            result.Add("/Modules/{2}/Views/{1}/{0}.cshtml");
-            result.Add("/Modules/{2}/Views/Shared/{0}.cshtml");
+            
+            result.Add("/" + _moduleFolderPerAreaName[context.AreaName] + "/{2}/Views/{1}/{0}.cshtml");
+            result.Add("/" + _moduleFolderPerAreaName[context.AreaName] + "/{2}/Views/Shared/{0}.cshtml");
 
             result.AddRange(viewLocations);
 

--- a/src/Orchard.Cms.Web/Orchard.Cms.Web.xproj
+++ b/src/Orchard.Cms.Web/Orchard.Cms.Web.xproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <DnxInvisibleFolder Include="App_Data\" />
     <DnxInvisibleFolder Include="Modules\" />
+	<DnxInvisibleFolder Include="UserModules\" />
     <DnxInvisibleFolder Include="Themes\" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Orchard.Cms.Web/appsettings.json
+++ b/src/Orchard.Cms.Web/appsettings.json
@@ -3,5 +3,6 @@
   "Modules": {
     "Orchard.Setup": {
     }
-  }
+  },
+  "ExtraModulesFolders": []
 }

--- a/src/Orchard.Cms.Web/project.json
+++ b/src/Orchard.Cms.Web/project.json
@@ -36,6 +36,7 @@
         "node_modules",
         "App_Data",
         "Modules",
+        "UserModules",
         "Themes"
       ]
     }
@@ -70,6 +71,7 @@
     "include": [
       "app_data",
       "modules",
+      "usermodules",
       "themes",
       "views",
       "_ViewStart.cshtml",


### PR DESCRIPTION
This PR implements #280
After this pull request if you want to have extra folders for modules you need to follow these steps:
- Add to `src/Orchard.Cms.Web/Orchard.Cms.Web.xproj` file an extra line like this `<DnxInvisibleFolder Include="YourExtraModuleFolder\" />` per each new folder.
- Add to `src/Orchard.Cms.Web/project.json` file extra lines to "buildOptions"->"compile"->"exclude" and "publishOptions"->"include" adding a line to them per each new folder.
-  Add to `src/Orchard.Cms.Web/appsettings.json` file an `ExtraModulesFolders` key with an array of the extra folders where Orchard will look for modules. An example:

```
﻿{
  // Sample organization for module specific settings
  "Modules": {
    "Orchard.Setup": {
    }
  }
  },
  "ExtraModulesFolders":  ["Modules.PCCom","Modules.XKProject"]
}
```
- Finally, you can add the modules in the extra folders to Orchard.sln
