### PR TITLE
If non Draftable, on edit and save no new version is created in the database.

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -455,7 +455,7 @@ namespace Orchard.Contents.Controllers
             }
 
             ContentTypeDefinition typeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
-            var draftRequired = (!contentItem.Published) || (typeDefinition.Settings.ToObject<ContentTypeSettings>().Draftable);
+            var draftRequired = contentItem.Published && typeDefinition.Settings.ToObject<ContentTypeSettings>().Draftable;
 
             if (draftRequired)
             {
@@ -490,14 +490,12 @@ namespace Orchard.Contents.Controllers
                 return View("Edit", model);
             }
 
-            if (draftRequired)
-            {
-                await conditionallyPublish(contentItem);
-            }
-            else
+            if (!draftRequired)
             {
                 _session.Save(contentItem);
             }
+
+            await conditionallyPublish(contentItem);
 
             //if (!string.IsNullOrWhiteSpace(returnUrl)
             //    && previousRoute != null

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -461,10 +461,6 @@ namespace Orchard.Contents.Controllers
             {
                 contentItem = await _contentManager.GetAsync(id, VersionOptions.DraftRequired);
             }
-            else
-            {
-                _session.Save(contentItem);
-            }
 
             if (contentItem == null)
             {
@@ -497,6 +493,10 @@ namespace Orchard.Contents.Controllers
             if (draftRequired)
             {
                 await conditionallyPublish(contentItem);
+            }
+            else
+            {
+                _session.Save(contentItem);
             }
 
             //if (!string.IsNullOrWhiteSpace(returnUrl)

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -454,22 +454,22 @@ namespace Orchard.Contents.Controllers
                 return NotFound();
             }
 
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.EditContent, contentItem))
+            {
+                return Unauthorized();
+            }
+
             ContentTypeDefinition typeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
             var draftRequired = contentItem.Published && typeDefinition.Settings.ToObject<ContentTypeSettings>().Draftable;
 
             if (draftRequired)
             {
                 contentItem = await _contentManager.GetAsync(id, VersionOptions.DraftRequired);
-            }
 
-            if (contentItem == null)
-            {
-                return NotFound();
-            }
-
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.EditContent, contentItem))
-            {
-                return Unauthorized();
+                if (contentItem == null)
+                {
+                    return NotFound();
+                }
             }
 
             //string previousRoute = null;

--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -108,5 +108,25 @@ namespace Orchard.ContentManagement
                    content.ContentItem.Published == false ||
                    (content.ContentItem.Published && content.ContentItem.Latest == false);
         }
+
+        public static bool IsLatest(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Latest;
+        }
+
+        public static bool IsNew(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Id == 0;
+        }
+
+        public static bool IsNewInstance(this IContent content)
+        {
+            return content.ContentItem.IsNew() && content.ContentItem.Number == 0;
+        }
+
+        public static bool IsNewVersion(this IContent content)
+        {
+            return content.ContentItem.IsNew() && content.ContentItem.Number != 0;
+        }
     }
 }

--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -113,20 +113,5 @@ namespace Orchard.ContentManagement
         {
             return content.ContentItem != null && content.ContentItem.Latest;
         }
-
-        public static bool IsNew(this IContent content)
-        {
-            return content.ContentItem != null && content.ContentItem.Id == 0;
-        }
-
-        public static bool IsNewInstance(this IContent content)
-        {
-            return content.ContentItem.IsNew() && content.ContentItem.Number == 0;
-        }
-
-        public static bool IsNewVersion(this IContent content)
-        {
-            return content.ContentItem.IsNew() && content.ContentItem.Number != 0;
-        }
     }
 }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -20,7 +20,6 @@ namespace Orchard.ContentManagement
         /// <param name="contentType">The name of the content type</param>
         ContentItem New(string contentType);
 
-
         /// <summary>
         /// Creates (persists) a new content item
         /// </summary>

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -171,13 +171,11 @@ namespace Orchard.ContentManagement
 
             if (contentItem == null)
             {
-                // TODO: Check if it is right to always return null here.
                 return null;
-                // Anyway if contentItem is null we can't do the following.
             }
 
             // Return item if obtained earlier in session
-            // If IsPublished is required then the test has already been checked before
+            // If IsPublished or IsLatest is required then the test has already been checked before
             ContentItem recalled = null;
             if (!_contentManagerSession.RecallVersionId(contentItem.Id, out recalled))
             {

--- a/src/Orchard.ContentManagement/DefaultContentManagerSession.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManagerSession.cs
@@ -62,7 +62,16 @@ namespace Orchard.ContentManagement
                 return false;
             }
 
-            return _publishedItemsById.TryGetValue(id, out item);
+            if (_publishedItemsById.TryGetValue(id, out item))
+            {
+                if (!item.Published)
+                {
+                    _publishedItemsById.Remove(id);
+                    item = null;
+                }
+            }
+
+            return item != null;
         }
 
         public bool RecallLatestItemId(int id, out ContentItem item)
@@ -73,7 +82,16 @@ namespace Orchard.ContentManagement
                 return false;
             }
 
-            return _latestItemsById.TryGetValue(id, out item);
+            if (_latestItemsById.TryGetValue(id, out item))
+            {
+                if (!item.Latest)
+                {
+                    _latestItemsById.Remove(id);
+                    item = null;
+                }
+            }
+
+            return item != null;
         }
 
         public void Clear()

--- a/src/Orchard.ContentManagement/DefaultContentManagerSession.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManagerSession.cs
@@ -8,6 +8,7 @@ namespace Orchard.ContentManagement
         private readonly IDictionary<int, ContentItem> _itemByVersionId = new Dictionary<int, ContentItem>();
         private readonly IDictionary<Tuple<int, int>, ContentItem> _itemByContentItemId = new Dictionary<Tuple<int, int>, ContentItem>();
         private readonly IDictionary<int, ContentItem> _publishedItemsById = new Dictionary<int, ContentItem>();
+        private readonly IDictionary<int, ContentItem> _latestItemsById = new Dictionary<int, ContentItem>();
 
         private bool _hasItems;
 
@@ -17,6 +18,12 @@ namespace Orchard.ContentManagement
 
             _itemByVersionId.Add(item.Id, item);
             _itemByContentItemId.Add(Tuple.Create(item.ContentItemId, item.Number), item);
+
+            // is it the latest version ?
+            if (item.Latest)
+            {
+                _latestItemsById[item.ContentItemId] = item;
+            }
 
             // is it the Published version ?
             if (item.Published)
@@ -58,11 +65,23 @@ namespace Orchard.ContentManagement
             return _publishedItemsById.TryGetValue(id, out item);
         }
 
+        public bool RecallLatestItemId(int id, out ContentItem item)
+        {
+            if (!_hasItems)
+            {
+                item = null;
+                return false;
+            }
+
+            return _latestItemsById.TryGetValue(id, out item);
+        }
+
         public void Clear()
         {
             _itemByVersionId.Clear();
             _itemByContentItemId.Clear();
             _publishedItemsById.Clear();
+            _latestItemsById.Clear();
             _hasItems = false;
         }
     }


### PR DESCRIPTION
Fixes #292.

Note: In the related issue we was also talking about `Validate` drivers, i'll open a new issue to be clearer.

So here, the non Draftable option gives the ability not to have many versions items in the database.

Best.
