### PR TITLE
Persists a content item only after validation.

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -352,7 +352,7 @@ namespace Orchard.Contents.Controllers
                 return Unauthorized();
             }
 
-            _contentManager.Create(contentItem, VersionOptions.Draft);
+            _contentManager.Create(contentItem, VersionOptions.Draft, transient: true);
 
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this);
 
@@ -361,6 +361,8 @@ namespace Orchard.Contents.Controllers
                 _session.Cancel();
                 return View(model);
             }
+
+            _session.Save(contentItem);
 
             await conditionallyPublish(contentItem);
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -352,7 +352,7 @@ namespace Orchard.Contents.Controllers
                 return Unauthorized();
             }
 
-            _contentManager.Create(contentItem, VersionOptions.Draft, transient: true);
+            _contentManager.Create(contentItem, VersionOptions.DraftTransient);
 
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this);
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -352,8 +352,6 @@ namespace Orchard.Contents.Controllers
                 return Unauthorized();
             }
 
-            _contentManager.Create(contentItem, VersionOptions.DraftTransient);
-
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this);
 
             if (!ModelState.IsValid)
@@ -362,7 +360,7 @@ namespace Orchard.Contents.Controllers
                 return View(model);
             }
 
-            _session.Save(contentItem);
+            _contentManager.Create(contentItem, VersionOptions.Draft);
 
             await conditionallyPublish(contentItem);
 

--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -108,5 +108,25 @@ namespace Orchard.ContentManagement
                    content.ContentItem.Published == false ||
                    (content.ContentItem.Published && content.ContentItem.Latest == false);
         }
+
+        public static bool IsLatest(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Latest;
+        }
+
+        public static bool IsNew(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Id == 0;
+        }
+
+        public static bool IsNewInstance(this IContent content)
+        {
+            return content.ContentItem.IsNew() && content.ContentItem.Number == 0;
+        }
+
+        public static bool IsNewVersion(this IContent content)
+        {
+            return content.ContentItem.IsNew() && content.ContentItem.Number != 0;
+        }
     }
 }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -32,8 +32,7 @@ namespace Orchard.ContentManagement
         /// </summary>
         /// <param name="contentItem">The content instance filled with all necessary data</param>
         /// <param name="options">The version to create the item with</param>
-        /// <param name="transient">The item is not yet persisted</param>
-        void Create(ContentItem contentItem, VersionOptions options, bool transient = false);
+        void Create(ContentItem contentItem, VersionOptions options);
 
         /// <summary>
         /// Gets the content item with the specified id
@@ -84,6 +83,11 @@ namespace Orchard.ContentManagement
         public static VersionOptions DraftRequired { get { return new VersionOptions { IsDraft = true, IsDraftRequired = true }; } }
 
         /// <summary>
+        /// Creates a new draft which is not yet persisted.
+        /// </summary>
+        public static VersionOptions DraftTransient { get { return new VersionOptions { IsDraft = true, IsDraftTransient = true }; } }
+
+        /// <summary>
         /// Gets all versions.
         /// </summary>
         public static VersionOptions AllVersions { get { return new VersionOptions { IsAllVersions = true }; } }
@@ -107,6 +111,7 @@ namespace Orchard.ContentManagement
         public bool IsPublished { get; private set; }
         public bool IsDraft { get; private set; }
         public bool IsDraftRequired { get; private set; }
+        public bool IsDraftTransient { get; private set; }
         public bool IsAllVersions { get; private set; }
         public int VersionNumber { get; private set; }
         public int VersionRecordId { get; private set; }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -32,7 +32,8 @@ namespace Orchard.ContentManagement
         /// </summary>
         /// <param name="contentItem">The content instance filled with all necessary data</param>
         /// <param name="options">The version to create the item with</param>
-        void Create(ContentItem contentItem, VersionOptions options);
+        /// <param name="transient">The item is not yet persisted</param>
+        void Create(ContentItem contentItem, VersionOptions options, bool transient = false);
 
         /// <summary>
         /// Gets the content item with the specified id

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -20,7 +20,6 @@ namespace Orchard.ContentManagement
         /// <param name="contentType">The name of the content type</param>
         ContentItem New(string contentType);
 
-
         /// <summary>
         /// Creates (persists) a new content item
         /// </summary>
@@ -83,11 +82,6 @@ namespace Orchard.ContentManagement
         public static VersionOptions DraftRequired { get { return new VersionOptions { IsDraft = true, IsDraftRequired = true }; } }
 
         /// <summary>
-        /// Creates a new draft which is not yet persisted.
-        /// </summary>
-        public static VersionOptions DraftTransient { get { return new VersionOptions { IsDraft = true, IsDraftTransient = true }; } }
-
-        /// <summary>
         /// Gets all versions.
         /// </summary>
         public static VersionOptions AllVersions { get { return new VersionOptions { IsAllVersions = true }; } }
@@ -111,7 +105,6 @@ namespace Orchard.ContentManagement
         public bool IsPublished { get; private set; }
         public bool IsDraft { get; private set; }
         public bool IsDraftRequired { get; private set; }
-        public bool IsDraftTransient { get; private set; }
         public bool IsAllVersions { get; private set; }
         public int VersionNumber { get; private set; }
         public int VersionRecordId { get; private set; }

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -372,11 +372,8 @@ namespace Orchard.ContentManagement
                 Handlers.Reverse().Invoke(handler => handler.Published(publishContext), _logger);
             }
 
-            if (!options.IsDraftTransient)
-            {
-                _session.Save(contentItem);
-                _contentManagerSession.Store(contentItem);
-            }
+            _session.Save(contentItem);
+            _contentManagerSession.Store(contentItem);
         }
 
         public ContentItemMetadata GetItemMetadata(IContent content)

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -332,7 +332,7 @@ namespace Orchard.ContentManagement
             Create(contentItem, VersionOptions.Published);
         }
 
-        public void Create(ContentItem contentItem, VersionOptions options)
+        public void Create(ContentItem contentItem, VersionOptions options, bool transient = false)
         {
             if (contentItem.Number == 0)
             {
@@ -372,8 +372,11 @@ namespace Orchard.ContentManagement
                 Handlers.Reverse().Invoke(handler => handler.Published(publishContext), _logger);
             }
 
-            _session.Save(contentItem);
-            _contentManagerSession.Store(contentItem);
+            if (!transient)
+            {
+                _session.Save(contentItem);
+                _contentManagerSession.Store(contentItem);
+            }
         }
 
         public ContentItemMetadata GetItemMetadata(IContent content)

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -332,7 +332,7 @@ namespace Orchard.ContentManagement
             Create(contentItem, VersionOptions.Published);
         }
 
-        public void Create(ContentItem contentItem, VersionOptions options, bool transient = false)
+        public void Create(ContentItem contentItem, VersionOptions options)
         {
             if (contentItem.Number == 0)
             {
@@ -372,7 +372,7 @@ namespace Orchard.ContentManagement
                 Handlers.Reverse().Invoke(handler => handler.Published(publishContext), _logger);
             }
 
-            if (!transient)
+            if (!options.IsDraftTransient)
             {
                 _session.Save(contentItem);
                 _contentManagerSession.Store(contentItem);


### PR DESCRIPTION
Related to #292, only for the part of `Validating`.

As discussed not sure, so just to give the idea and because i remember better why it is used in O1.

- So, in O1 it is not to create item and version records before validation, this when `Creating` (not editing) `Comments` through the front end. This by using a transient instance before update and validation.

- In O2, as discussed, an item is also a version but with the regular pattern there is still a `_session.Save()` before validation and then before a possible `_session.Cancel()`. But not sure it has an impact in O2, thinking about something like a `Comments module`, not a regular admin controller.

- So, here we can create a transient item which can therefore be persisted only after validation. Just for showing, i use it in the admin controller of the contents module, let me know if it is useful here.

- Just to show, i used the simpler way with a `transient` boolean argument but we could use a new `VersionOptions` or a `validation async delegate` passed to a new `CreateAsync()`. Let me know.

- I added some `ContentExtensions`. If the above is useless, maybe we could keep them after reviewing.

Best.