### PR TITLE
fix(Contents): incorrect pager for admin content

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -151,10 +151,11 @@ namespace Orchard.Contents.Controllers
             await _contentAdminFilters.InvokeAsync(x => x.FilterAsync(query, model, pagerParameters, this), Logger);
 
             var maxPagedCount = siteSettings.MaxPagedCount;
+            var actualCount = await query.Count();
             if (maxPagedCount > 0 && pager.PageSize > maxPagedCount)
                 pager.PageSize = maxPagedCount;
 
-            var pagerShape = New.Pager(pager).TotalItemCount(maxPagedCount > 0 ? maxPagedCount : await query.Count());
+            var pagerShape = New.Pager(pager).TotalItemCount(actualCount > maxPagedCount ? maxPagedCount : actualCount);
             var pageOfContentItems = await query.Skip(pager.GetStartIndex()).Take(pager.PageSize).List();
 
             var contentItemSummaries = new List<dynamic>();


### PR DESCRIPTION
Before we have display max page counts always, no matter how many pages we have actually.

Now we show max page count only if actual page count more than max allowed.