### PR TITLE
1st work in GetShapeTable() on async and Lazy<Task> to cache more jobs.

### DIFF
--- a/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -19,7 +19,7 @@ namespace Orchard.DisplayManagement.Descriptors
     public class DefaultShapeTableManager : IShapeTableManager
     {
         private static ConcurrentDictionary<int, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<int, FeatureShapeDescriptor>();
-        private static ConcurrentDictionary<int, Lazy<bool>> _buildDescriptorResults = new ConcurrentDictionary<int, Lazy<bool>>();
+        private static ConcurrentDictionary<string, Lazy<bool>> _buildDescriptorResults = new ConcurrentDictionary<string, Lazy<bool>>();
 
         private readonly IEnumerable<IShapeTableProvider> _bindingStrategies;
         private readonly IExtensionManager _extensionManager;
@@ -110,7 +110,7 @@ namespace Orchard.DisplayManagement.Descriptors
             IEnumerable<ShapeAlteration> builtAlterations = null;
 
             var result = _memoryCache.GetOrCreate(
-                bindingStrategy.GetType().FullName.GetHashCode(), entry =>
+                bindingStrategy.GetType().FullName, entry =>
                 {
                     entry.Priority = CacheItemPriority.NeverRemove;
 
@@ -135,10 +135,9 @@ namespace Orchard.DisplayManagement.Descriptors
             {
                 var firstAlteration = alterations.First();
 
-                var key = (bindingStrategy.GetType().Name
+                var key = bindingStrategy.GetType().Name
                     + firstAlteration.Feature.Descriptor.Id
-                    + firstAlteration.ShapeType).ToLower()
-                    .GetHashCode();
+                    + firstAlteration.ShapeType;
 
                 var result = _buildDescriptorResults.GetOrAdd(key, k =>
                 {
@@ -155,7 +154,7 @@ namespace Orchard.DisplayManagement.Descriptors
                             alteration.Alter(descriptor);
                         }
 
-                        _shapeDescriptors[key] = descriptor;
+                        _shapeDescriptors[key.GetHashCode()] = descriptor;
                         return true;
                     });
 

--- a/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -17,7 +17,7 @@ namespace Orchard.DisplayManagement.Descriptors
     /// </summary>
     public class DefaultShapeTableManager : IShapeTableManager
     {
-        private static ConcurrentDictionary<int, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<int, FeatureShapeDescriptor>();
+        private static ConcurrentDictionary<string, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<string, FeatureShapeDescriptor>();
 
         private readonly IEnumerable<IShapeTableProvider> _bindingStrategies;
         private readonly IExtensionManager _extensionManager;
@@ -113,10 +113,9 @@ namespace Orchard.DisplayManagement.Descriptors
             {
                 var firstAlteration = alterations.First();
 
-                var key = (bindingStrategy.GetType().Name
+                var key = bindingStrategy.GetType().Name
                     + firstAlteration.Feature.Descriptor.Id
-                    + firstAlteration.ShapeType.ToLower())
-                    .GetHashCode();
+                    + firstAlteration.ShapeType.ToLower();
 
                 if (!_shapeDescriptors.ContainsKey(key))
                 {
@@ -136,12 +135,12 @@ namespace Orchard.DisplayManagement.Descriptors
             }
         }
 
-        private static int GetPriority(KeyValuePair<int, FeatureShapeDescriptor> shapeDescriptor)
+        private static int GetPriority(KeyValuePair<string, FeatureShapeDescriptor> shapeDescriptor)
         {
             return shapeDescriptor.Value.Feature.Descriptor.Priority;
         }
 
-        private bool DescriptorHasDependency(KeyValuePair<int, FeatureShapeDescriptor> item, KeyValuePair<int, FeatureShapeDescriptor> subject)
+        private bool DescriptorHasDependency(KeyValuePair<string, FeatureShapeDescriptor> item, KeyValuePair<string, FeatureShapeDescriptor> subject)
         {
             return _extensionManager.HasDependency(item.Value.Feature.Descriptor, subject.Value.Feature.Descriptor);
         }

--- a/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -76,7 +76,7 @@ namespace Orchard.DisplayManagement.Descriptors
                     if ((builtAlterations?.Count() ?? 0) == 0)
                         continue;
 
-                    BuildDescriptorsAsync(bindingStrategy, builtAlterations);
+                    BuildDescriptorsAsync(bindingStrategy, builtAlterations).Wait();
                 }
 
                 var enabledFeatureIds = _featureManager.GetEnabledFeaturesAsync().Result.Select(fd => fd.Id).ToList();
@@ -133,7 +133,7 @@ namespace Orchard.DisplayManagement.Descriptors
             return builtAlterations;
         }
 
-        private async void BuildDescriptorsAsync(IShapeTableProvider bindingStrategy, IEnumerable<ShapeAlteration> builtAlterations)
+        private async Task<Task> BuildDescriptorsAsync(IShapeTableProvider bindingStrategy, IEnumerable<ShapeAlteration> builtAlterations)
         {
             var alterationSets = builtAlterations.GroupBy(a => a.Feature.Descriptor.Id + a.ShapeType);
 
@@ -168,6 +168,8 @@ namespace Orchard.DisplayManagement.Descriptors
 
                 }).Value;
             }
+
+            return Task.CompletedTask;
         }
 
         private static int GetPriority(KeyValuePair<int, FeatureShapeDescriptor> shapeDescriptor)

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeDescriptor.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeDescriptor.cs
@@ -22,10 +22,10 @@ namespace Orchard.DisplayManagement.Descriptors
 
     public class ShapeDescriptorIndex : ShapeDescriptor
     {
-        private IEnumerable<int> _alterationKeys;
-        private ConcurrentDictionary<int, FeatureShapeDescriptor> _descriptors;
+        private IEnumerable<string> _alterationKeys;
+        private ConcurrentDictionary<string, FeatureShapeDescriptor> _descriptors;
 
-        public ShapeDescriptorIndex(string shapeType, IEnumerable<int> alterationKeys, ConcurrentDictionary<int, FeatureShapeDescriptor> descriptors)
+        public ShapeDescriptorIndex(string shapeType, IEnumerable<string> alterationKeys, ConcurrentDictionary<string, FeatureShapeDescriptor> descriptors)
         {
             ShapeType = shapeType;
             _alterationKeys = alterationKeys;


### PR DESCRIPTION
Just to save a 1st work on this.

- We already cache things not to do duplicate jobs but here it' when there are simultaneous requests.

- Thinking about your suggestion to cache and wait a `Task` and after searching on google, i've used a compromise. In a few words, a `Lazy` to execute once a `Task` that can be awaited.

- I don't really use this technique to retrieve data, but to execute some identified jobs only once.

- E.g with a static dictionary which cache some jobs to do only once.

                var variable = await _staticDictionary.GetOrAdd
                (key, (k) =>
                {
                    return new Lazy<Task<bool>>(() => Task.Run(() =>
                    {
                        // here the job we want to run only once
                        // which may build and / or cache objects

                        // return a simple bool
                        return Task.FromResult(true);
                    }));

                }).Value;

- ShapeAlteration building jobs (depend on table providers) are cached per tenant (memory cache).

- Each ShapeDescriptor building job related to a feature is cached at the app level (static dictionary).

- Right now, it breaks 2 unit tests because we are caching more `IShapeTableProvider` jobs.

- There are still some possible part of duplicate jobs between tenants but there are minimized.

Best.