### PR TITLE
#286 Running Orchard as service without IIS

### DIFF
--- a/src/Orchard.Cms.Web/OrchardCmsWin32Service.cs
+++ b/src/Orchard.Cms.Web/OrchardCmsWin32Service.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using DasMulli.Win32.ServiceUtils;
+using System.Threading;
+using Microsoft.AspNetCore.Hosting;
+using Orchard.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using System.Linq;
+
+namespace Orchard.Cms.Web
+{
+    public class OrchardCmsWin32Service : IWin32Service
+    {
+        private readonly string[] _commandLineArguments;
+        private readonly bool _useInteractiveCommandLine;
+
+        private bool _stopRequestedByWindows;
+        private IWebHost _host;
+        
+        public OrchardCmsWin32Service(string[] commandLineArguments, bool useInteractiveCommandLine)
+        {
+            _commandLineArguments = commandLineArguments;
+            _useInteractiveCommandLine = useInteractiveCommandLine;
+        }
+
+        public string ServiceName => "Orchard Service";
+
+        public void Start(string[] startupArguments, ServiceStoppedCallback serviceStoppedCallback)
+        {
+            string[] combinedArguments;
+            if (startupArguments.Length > 0)
+            {
+                combinedArguments = new string[_commandLineArguments.Length + startupArguments.Length];
+                Array.Copy(_commandLineArguments, combinedArguments, _commandLineArguments.Length);
+                Array.Copy(startupArguments, 0, combinedArguments, _commandLineArguments.Length, startupArguments.Length);
+            }
+            else
+            {
+                combinedArguments = _commandLineArguments;
+            }
+
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(combinedArguments)
+                .Build();
+
+            _host = new WebHostBuilder()
+                .UseIISIntegration()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseStartup<Startup>()
+                .UseConfiguration(config)
+                .Build();
+
+            if (_useInteractiveCommandLine)
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    _host.Run((services) =>
+                    {
+                        var orchardHost = new OrchardHost(
+                            services,
+                            System.Console.In,
+                            System.Console.Out,
+                            combinedArguments);
+
+                        orchardHost
+                            .RunAsync()
+                            .Wait();
+                        cts.Cancel();
+                    }, cts.Token, "Application started. Press Ctrl+C to shut down.");
+                    return;
+                }
+            }
+            else
+            {
+                // Make sure the windows service is stopped if the
+                // ASP.NET Core stack stops for any reason
+                _host.Services
+                .GetRequiredService<IApplicationLifetime>()
+                .ApplicationStopped
+                .Register(() =>
+                {
+                    if (_stopRequestedByWindows == false)
+                    {
+                        serviceStoppedCallback();
+                    }
+                });
+
+                _host.Start();
+            }
+        }
+        public void Stop()
+        {
+            _stopRequestedByWindows = true;
+            _host.Dispose();
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Program.cs
+++ b/src/Orchard.Cms.Web/Program.cs
@@ -1,42 +1,121 @@
-﻿using System.IO;
-using System.Threading;
-using Microsoft.AspNetCore.Hosting;
-using Orchard.Hosting;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DasMulli.Win32.ServiceUtils;
+using Microsoft.DotNet.InternalAbstractions;
+using System.IO;
 
 namespace Orchard.Cms.Web
 {
     public class Program
     {
+        public const string RunAsServiceFlag = "--run-as-service";
+        private const string RegisterServiceFlag = "--register-service";
+        private const string UnregisterServiceFlag = "--unregister-service";
+        private const string HelpFlag = "--?";
+
+        private const string ServiceName = "Orchard 2";
+        private const string ServiceDisplayName = "Orchard 2";
+        private const string ServiceDescription = "Orchard 2 CMS running on .NET Core";
+
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                .UseIISIntegration()
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseStartup<Startup>()
-                .Build();
-
-            using (host)
+            try
             {
-                using (var cts = new CancellationTokenSource())
+                if (args.Contains(RunAsServiceFlag))
                 {
-                    host.Run((services) =>
-                    {
-                        var orchardHost = new OrchardHost(
-                            services,
-                            System.Console.In,
-                            System.Console.Out,
-                            args);
-
-                        orchardHost
-                            .RunAsync()
-                            .Wait();
-
-                        cts.Cancel();
-
-                    }, cts.Token, "Application started. Press Ctrl+C to shut down.");
+                    RunAsService(args);
+                }
+                else if (args.Contains(RegisterServiceFlag))
+                {
+                    RegisterService();
+                }
+                else if (args.Contains(UnregisterServiceFlag))
+                {
+                    UnregisterService();
+                }
+                else if (args.Contains(HelpFlag))
+                {
+                    DisplayHelp();
+                }
+                else
+                {
+                    RunInteractive(args);
                 }
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error ocurred: {ex.Message}");
+            }
+        }
+
+        private static void RunAsService(string[] args)
+        {
+            var appPath = ApplicationEnvironment.ApplicationBasePath;
+            while (!File.Exists(appPath + "\\web.config"))
+            {
+                appPath = Directory.GetParent(appPath).FullName;
+            }
+
+            System.IO.Directory.SetCurrentDirectory(appPath);
+            var orchardService = new OrchardCmsWin32Service(commandLineArguments: args.Where(a => a != RunAsServiceFlag).ToArray(), useInteractiveCommandLine: false);
+            var serviceHost = new Win32ServiceHost(orchardService);
+            serviceHost.Run();
+        }
+
+        private static void RunInteractive(string[] args)
+        {
+            var orchardService = new OrchardCmsWin32Service(commandLineArguments: args, useInteractiveCommandLine: true);
+            orchardService.Start(new string[0], () => { });
+            orchardService.Stop();
+        }
+
+        private static void RegisterService()
+        {
+            // Environment.GetCommandLineArgs() includes the current DLL from a "dotnet my.dll --register-service" call, which is not passed to Main()
+            var remainingArgs = System.Environment.GetCommandLineArgs()
+                .Where(arg => arg != RegisterServiceFlag)
+                .Select(EscapeCommandLineArgument)
+                .Append(RunAsServiceFlag);
+
+            var host = Process.GetCurrentProcess().MainModule.FileName;
+            if (!host.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+            {
+                // For self-contained apps, skip the dll path
+                remainingArgs = remainingArgs.Skip(1);
+            }
+
+            var fullServiceCommand = host + " " + string.Join(" ", remainingArgs);
+            new Win32ServiceManager()
+              .CreateService(ServiceName, ServiceDisplayName, ServiceDescription, fullServiceCommand, new Win32ServiceCredentials("NT SERVICE\\" + ServiceName, null), autoStart: true, startImmediately: true, errorSeverity: ErrorSeverity.Normal);
+
+          Console.WriteLine($@"Successfully registered and started service ""{ServiceDisplayName}"" (""{ServiceDescription}"")");
+        }
+
+        private static void UnregisterService()
+        {
+            new Win32ServiceManager()
+                                    .DeleteService(ServiceName);
+            Console.WriteLine($@"Successfully unregistered service ""{ServiceDisplayName}"" (""{ServiceDescription}"")");
+        }
+
+        private static void DisplayHelp()
+        {
+            Console.WriteLine(ServiceDescription);
+            Console.WriteLine();
+            Console.WriteLine("Use one of the following options for running Orchard as a windows service or standalone:");
+            Console.WriteLine("  --register-service        Registers and starts this program as a windows service named \"" + ServiceDisplayName + "\"");
+            Console.WriteLine("                            All additional arguments will be passed to ASP.NET Core's WebHostBuilder.");
+            Console.WriteLine("  --unregister-service      Removes the windows service created by --register-service.");
+        }
+
+        private static string EscapeCommandLineArgument(string arg)
+        {
+            // http://stackoverflow.com/a/6040946/784387
+            arg = Regex.Replace(arg, @"(\\*)" + "\"", @"$1$1\" + "\"");
+            arg = "\"" + Regex.Replace(arg, @"(\\+)$", @"$1$1") + "\"";
+            return arg;
         }
     }
 }

--- a/src/Orchard.Cms.Web/project.json
+++ b/src/Orchard.Cms.Web/project.json
@@ -15,7 +15,9 @@
     "Microsoft.AspNetCore.Diagnostics": "1.1.0",
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
     "System.Dynamic.Runtime": "4.3.0",
-    "Microsoft.Extensions.Localization.Abstractions": "1.1.0"
+    "Microsoft.Extensions.Localization.Abstractions": "1.1.0",
+    "DasMulli.Win32.ServiceUtils": "1.0.1",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0"
   },
   "runtimeOptions": {
     "configProperties": {


### PR DESCRIPTION
This PR moves WebHostBuilder initialization  from Program.cs to OrchardCmsWin32Service.cs .
Program.cs class in this PR is only focused on handling arguments received by command line for running Orchard as a service or as a regular app #286 . The arguments available are the following ones:
  --register-service        Registers and starts this program as a windows service named "Orchard 2"
  --unregister-service    Removes the windows service

All additional arguments now will be passed to ASP.NET Core's WebHostBuilder that now accepts it to set configuration.

We can start Orchard standalone listening on http://localhost:5080:
`dotnet Orchard.Cms.Web.dll --urls http://localhost:5080`

We can register and start it:
`dotnet Orchard.Cms.Web.dll --register-service --urls http://localhost:5080`

We can unregister it (if it is stopped):
`dotnet Orchard.Cms.Web.dll --unregister-service 

Currently the service is run as user LocalSystem. Next is to provide the ability of running it as another user.
Almost all the code is pasted from the sample provided by @dasMulli at https://github.com/dasMulli/dotnet-win32-service to use his library.

-- EDIT --
By the moment I managed to run Orchard as a service only after compiling and publishing the app using previously mentioned parameters. If I run it directly as a service from source code orchard doesn't answer. It doesn't look a relevant problem but I advice you because if you want to make it work is good to know this limitation.




