### PR TITLE
Precompiled views fixes.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ApplicationBuilderExtensions.cs
@@ -1,18 +1,15 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
-using Orchard;
 using Orchard.Environment.Extensions;
 using Orchard.Hosting;
 using Orchard.Hosting.Web.Routing;
-using System.IO;
-using System.Linq;
-
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
 {

--- a/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
+++ b/src/Orchard.Environment.Extensions/Compilers/CSharpExtensionCompiler.cs
@@ -29,15 +29,27 @@ namespace Orchard.Environment.Extensions.Compilers
         private static readonly Lazy<RuntimeLibrary> _nativePDBWriter = new Lazy<RuntimeLibrary>(GetNativePDBWriter);
         private static readonly Lazy<HashSet<string>> _ambientLibraries = new Lazy<HashSet<string>>(GetAmbientLibraries);
         private static readonly ConcurrentDictionary<string, bool> _compiledLibraries = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-        private static readonly Lazy<Assembly> _entryAssembly = new Lazy<Assembly>(Assembly.GetEntryAssembly);
+        private static readonly Lazy<string> _entryAssemblyName = new Lazy<string>(GetEntryAssemblyName);
+        private static readonly Lazy<string> _runtimeDirectory = new Lazy<string>(GetRuntimeDirectory);
 
-        public CSharpExtensionCompiler ()
+        public CSharpExtensionCompiler()
         {
             Diagnostics = new List<string>();
         }
 
-        public static Assembly EntryAssembly => _entryAssembly.Value;
+        public static string EntryAssemblyName => _entryAssemblyName.Value;
+        public static string RuntimeDirectory => _runtimeDirectory.Value;
         public IList<string> Diagnostics { get; private set; }
+
+        private static string GetRuntimeDirectory()
+        {
+            return Paths.GetParentFolderPath(typeof(CSharpExtensionCompiler).GetTypeInfo().Assembly.Location);
+        }
+
+        private static string GetEntryAssemblyName()
+        {
+            return DependencyContext.Default?.RuntimeLibraries.First().Name;
+        }
 
         private static RuntimeLibrary GetCscLibrary()
         {
@@ -95,7 +107,7 @@ namespace Orchard.Environment.Extensions.Compilers
                 return _compiledLibraries[context.ProjectName()] = true;
             }
 
-           // Set up Output Paths
+            // Set up Output Paths
             var outputPaths = context.GetOutputPaths(config);
             var outputPath = outputPaths.CompilationOutputPath;
             var intermediateOutputPath = outputPaths.IntermediateOutputDirectoryPath;
@@ -124,9 +136,6 @@ namespace Orchard.Environment.Extensions.Compilers
             var sourceFiles = new List<string>();
             var resources = new List<string>();
 
-            // Get the runtime directory
-            var runtimeDirectory = Paths.GetParentFolderPath(EntryAssembly.Location);
-
             foreach (var dependency in dependencies)
             {
                 sourceFiles.AddRange(dependency.SourceReferences.Select(s => s.GetTransformedFile(intermediateOutputPath)));
@@ -151,8 +160,8 @@ namespace Orchard.Environment.Extensions.Compilers
 
                         if (projectContext != null)
                         {
-                           // Right now, if !success we try to use the last build
-                           var success = Compile(projectContext, config, probingFolderPath);
+                            // Right now, if !success we try to use the last build
+                            var success = Compile(projectContext, config, probingFolderPath);
                         }
                     }
                 }
@@ -163,7 +172,7 @@ namespace Orchard.Environment.Extensions.Compilers
                     var assetFileName = CompilerUtility.GetAssemblyFileName(library.Identity.Name);
 
                     // Search in the runtime directory
-                    var assetResolvedPath = Path.Combine(runtimeDirectory, assetFileName);
+                    var assetResolvedPath = Path.Combine(RuntimeDirectory, assetFileName);
 
                     if (!File.Exists(assetResolvedPath))
                     {
@@ -196,7 +205,7 @@ namespace Orchard.Environment.Extensions.Compilers
 
                         // Search in the runtime directory
                         var relativeFolderPath = isRuntimeAsset ? String.Empty : CompilerUtility.RefsDirectoryName;
-                        var assetResolvedPath = Path.Combine(runtimeDirectory, relativeFolderPath, assetFileName);
+                        var assetResolvedPath = Path.Combine(RuntimeDirectory, relativeFolderPath, assetFileName);
 
                         if (!File.Exists(assetResolvedPath))
                         {
@@ -264,7 +273,7 @@ namespace Orchard.Environment.Extensions.Compilers
                 {
                     // Search in the regular project output path, fallback to the runtime directory
                     references.AddRange(dependency.CompilationAssemblies.Select(r => File.Exists(r.ResolvedPath)
-                        ? r.ResolvedPath : Path.Combine(runtimeDirectory, r.FileName)));
+                        ? r.ResolvedPath : Path.Combine(RuntimeDirectory, r.FileName)));
                 }
                 else
                 {
@@ -334,7 +343,7 @@ namespace Orchard.Environment.Extensions.Compilers
             var outputs = new List<string>();
 
             inputs.Add(context.ProjectFile.ProjectFilePath);
- 
+
             if (context.LockFile != null)
             {
                 inputs.Add(context.LockFile.LockFilePath);
@@ -408,8 +417,8 @@ namespace Orchard.Environment.Extensions.Compilers
             File.WriteAllLines(rsp, allArgs);
 
             // Locate runtime config files
-            var runtimeConfigPath = Path.Combine(runtimeDirectory, EntryAssembly.GetName().Name + FileNameSuffixes.RuntimeConfigJson);
-            var cscRuntimeConfigPath =  Path.Combine(runtimeDirectory, "csc" + FileNameSuffixes.RuntimeConfigJson);
+            var runtimeConfigPath = Path.Combine(RuntimeDirectory, EntryAssemblyName + FileNameSuffixes.RuntimeConfigJson);
+            var cscRuntimeConfigPath = Path.Combine(RuntimeDirectory, "csc" + FileNameSuffixes.RuntimeConfigJson);
 
             // Automatically create the csc runtime config file
             if (Files.IsNewer(runtimeConfigPath, cscRuntimeConfigPath))
@@ -424,11 +433,11 @@ namespace Orchard.Environment.Extensions.Compilers
             }
 
             // Locate csc.dll and the csc.exe asset
-            var cscDllPath = Path.Combine(runtimeDirectory, CompilerUtility.GetAssemblyFileName("csc"));
+            var cscDllPath = Path.Combine(RuntimeDirectory, CompilerUtility.GetAssemblyFileName("csc"));
 
             // Search in the runtime directory
             var cscRelativePath = Path.Combine("runtimes", "any", "native", "csc.exe");
-            var cscExePath = Path.Combine(runtimeDirectory, cscRelativePath);
+            var cscExePath = Path.Combine(RuntimeDirectory, cscRelativePath);
 
             // Fallback to the packages storage
             if (!File.Exists(cscExePath) && !String.IsNullOrEmpty(context.PackagesDirectory))
@@ -450,10 +459,10 @@ namespace Orchard.Environment.Extensions.Compilers
             }
 
             // Locate the csc dependencies file
-            var cscDepsPath = Path.Combine(runtimeDirectory, "csc.deps.json");
+            var cscDepsPath = Path.Combine(RuntimeDirectory, "csc.deps.json");
 
             // Automatically create csc.deps.json
-            if (NativePDBWriter!= null && Files.IsNewer(cscDllPath, cscDepsPath))
+            if (NativePDBWriter != null && Files.IsNewer(cscDllPath, cscDepsPath))
             {
                 lock (_syncLock)
                 {
@@ -480,7 +489,7 @@ namespace Orchard.Environment.Extensions.Compilers
 
                         // Windows native pdb writers are outputed on dotnet publish.
                         // But not on dotnet build during development, we do it here.
-                        
+
                         // Check if there is a packages storage
                         if (!String.IsNullOrEmpty(context.PackagesDirectory))
                         {
@@ -492,7 +501,7 @@ namespace Orchard.Environment.Extensions.Compilers
                                 var pdbResolvedPath = Path.Combine(context.PackagesDirectory,
                                     NativePDBWriter.Name, NativePDBWriter.Version, assetPath);
 
-                                var pdbOutputPath = Path.Combine(runtimeDirectory, assetPath);
+                                var pdbOutputPath = Path.Combine(RuntimeDirectory, assetPath);
 
                                 // Store the pdb writer in the runtime directory
                                 if (Files.IsNewer(pdbResolvedPath, pdbOutputPath))
@@ -508,7 +517,7 @@ namespace Orchard.Environment.Extensions.Compilers
 
             // Execute CSC!
             var result = Command.Create("csc.dll", new string[] { $"-noconfig", "@" + $"{rsp}" })
-                .WorkingDirectory(runtimeDirectory)
+                .WorkingDirectory(RuntimeDirectory)
                 .OnErrorLine(line => Diagnostics.Add(line))
                 .OnOutputLine(line => Diagnostics.Add(line))
                 .Execute();
@@ -566,7 +575,7 @@ namespace Orchard.Environment.Extensions.Compilers
             return ProjectContext.CreateContextForEachFramework(projectPath).FirstOrDefault();
         }
 
-        private string ResolveAssetPath(string binaryFolderPath, string probingFolderPath,  string assetFileName, string relativeFolderPath = null)
+        private string ResolveAssetPath(string binaryFolderPath, string probingFolderPath, string assetFileName, string relativeFolderPath = null)
         {
             return CompilerUtility.ResolveAssetPath(binaryFolderPath, probingFolderPath, assetFileName, relativeFolderPath);
         }

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -1,8 +1,16 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Compilation;
 using Microsoft.DotNet.ProjectModel.Graph;
@@ -13,13 +21,6 @@ using Microsoft.Extensions.Options;
 using NuGet.Packaging;
 using Orchard.Environment.Extensions.Compilers;
 using Orchard.Localization;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
 
 namespace Orchard.Environment.Extensions
 {
@@ -177,7 +178,7 @@ namespace Orchard.Environment.Extensions
         internal void CompileProject(ProjectContext context)
         {
 
-            var compiler = new CSharpExtensionCompiler();
+            var compiler = new CSharpExtensionCompiler(_hostingEnvironment.ApplicationName);
             var success = compiler.Compile(context, Configuration, _probingFolderPath);
             var diagnostics = compiler.Diagnostics;
 
@@ -718,7 +719,7 @@ namespace Orchard.Environment.Extensions
 
         private void PopulateRuntimeFolder(string assetPath, string relativeFolderPath = null)
         {
-            PopulateBinaryFolder(CSharpExtensionCompiler.RuntimeDirectory, assetPath, relativeFolderPath);
+            PopulateBinaryFolder(ApplicationEnvironment.ApplicationBasePath, assetPath, relativeFolderPath);
         }
     }
 }

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -642,12 +642,12 @@ namespace Orchard.Environment.Extensions
             return runtimeIds.Distinct();
         }
 
-        private bool IsAmbientExtension (IExtensionInfo extensionInfo)
+        private bool IsAmbientExtension(IExtensionInfo extensionInfo)
         {
-             return IsAmbientAssembly(extensionInfo.Id);
+            return IsAmbientAssembly(extensionInfo.Id);
         }
 
-        private bool IsDynamicContext (ProjectContext context)
+        private bool IsDynamicContext(ProjectContext context)
         {
             if (context == null)
             {
@@ -658,7 +658,7 @@ namespace Orchard.Environment.Extensions
             return CompilerUtility.GetCompilationSources(context, compilationOptions).Any();
         }
 
-        private bool IsPrecompiledContext (ProjectContext context)
+        private bool IsPrecompiledContext(ProjectContext context)
         {
             return context == null || !IsDynamicContext(context);
         }
@@ -718,8 +718,7 @@ namespace Orchard.Environment.Extensions
 
         private void PopulateRuntimeFolder(string assetPath, string relativeFolderPath = null)
         {
-            var runtimeDirectory = Paths.GetParentFolderPath(CSharpExtensionCompiler.EntryAssembly.Location);
-            PopulateBinaryFolder(runtimeDirectory, assetPath, relativeFolderPath);
+            PopulateBinaryFolder(CSharpExtensionCompiler.RuntimeDirectory, assetPath, relativeFolderPath);
         }
     }
 }


### PR DESCRIPTION
@sebastienros i've got something working even if we 1st delete all binaries, then build the app and run the tool. I don't really like the solution but it works, so i've put it here for discusion and you can try it.

**The issue**

- We need to know the runtime directory e.g to configure some csc.* files but when running from the tool the runtime directory was in the package storage (in a dev env packages are loaded from there).

- Indeed in one of the ViewCompilation packages i could see e.g our csc.* files (e.g csc.dll). So, **i've deleted these packages** and re-done a restore. Maybe it's good for you to do the same.

- **Warning** some weird references was still pointing on these files wrongly put there. So, to be able to re-build i also needed to delete all project.lock.json. As you can do with a git clean, i now have a poster ;).

**Current fix**

- So, to get our `runtime directory`,right now i use our `CSharpExtensionCompiler` Type to get its assembly which is in the runtime directory. We could assume that it should be ambient and always outputed here. But if we use the compiler from e.g a package, in a dev env this would not be the case.

- That's why i don't really like this solution but it works, so you can test the functionality. But let me know if you think it's ok to say that `CSharpExtensionCompiler` will always be in an ambient assembly.

- The runtime directory depends on the config, the framework, can be at the root in a published env ... but i've already done this kind of resolution, i'll take a look tomorrow. But it was so easy to use as before `Assembly.GetEntryAssembly()` but it doesn't work as we want when running from the tool.

- I also need the main assembly name but i can grab it easily from the default dependency context where it is always in the first place in the runtime assemblies collection.

- Otherwise we re-use the parallel foreach to have true parallelism and with a max degree of 4. Then in the delegate i've copy paste the previous code but i've removed the usage of async await. Let me know if it's still better to use them even in a delegate which is used in a parallel loop.

Best.