### PR TITLE
#375: Fixes 404s still evaluate Layout.

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
@@ -36,8 +36,7 @@ namespace Orchard.Admin
                 return;
             }
 
-            if (filterContext.HttpContext.Response.StatusCode < 200
-                || filterContext.HttpContext.Response.StatusCode >= 300)
+            if (filterContext.HttpContext.Response.StatusCode != 200)
             {
                 return;
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
@@ -36,6 +36,11 @@ namespace Orchard.Admin
                 return;
             }
 
+            if (filterContext.HttpContext.Response.StatusCode != 200)
+            {
+                return;
+            }
+
             // Populate main nav
             IShape menuShape = _shapeFactory.Create("Navigation",
                 Arguments.From(new

--- a/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Admin/AdminMenuFilter.cs
@@ -36,7 +36,8 @@ namespace Orchard.Admin
                 return;
             }
 
-            if (filterContext.HttpContext.Response.StatusCode != 200)
+            if (filterContext.HttpContext.Response.StatusCode < 200
+                || filterContext.HttpContext.Response.StatusCode >= 300)
             {
                 return;
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Diagnostics/Startup.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Diagnostics/Startup.cs
@@ -27,17 +27,22 @@ namespace Orchard.Diagnostics
 
             app.Use((context, next) =>
             {
-                string contentType;
-                if (_contentTypeProvider.TryGetContentType(context.Request.Path, out contentType))
+                var builder = next();
+
+                if (context.Response.StatusCode != 200)
                 {
-                    var statusCodePagesFeature = context.Features.Get<IStatusCodePagesFeature>();
-                    if (statusCodePagesFeature != null)
+                    string contentType;
+                    if (_contentTypeProvider.TryGetContentType(context.Request.Path, out contentType))
                     {
-                        statusCodePagesFeature.Enabled = false;
+                        var statusCodePagesFeature = context.Features.Get<IStatusCodePagesFeature>();
+                        if (statusCodePagesFeature != null)
+                        {
+                            statusCodePagesFeature.Enabled = false;
+                        }
                     }
                 }
 
-                return next();
+                return builder;
             });
 
             routes.MapAreaRoute(

--- a/src/Orchard.Cms.Web/Modules/Orchard.Diagnostics/project.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Diagnostics/project.json
@@ -6,6 +6,7 @@
     "Microsoft.AspNetCore.Mvc.Modules.Abstractions": "1.0.0-*",
     "Microsoft.AspNetCore.Diagnostics": "1.1.0",
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.1.0",
     "Orchard.DisplayManagement": "2.0.0-*"
   },
   "buildOptions": {


### PR DESCRIPTION
Fixes #375 

- 404s (or other errors) related to static files are not converted into custom views.

- `AdminMenuFilter` not rendered if status code is not 2xx.

Because now our error view is built only once, maybe good to still render the admin menu, this to go more easily to another page. So, let me know if it's still better to check if status code is not 2xx.

Best.