### PR TITLE
#376: View location expander for Controller Views and Components.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -68,11 +69,17 @@ namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
 
             services.Configure<RazorViewEngineOptions>(configureOptions: options =>
             {
-                var expander = new ModuleViewLocationExpander();
+                var serviceProvider = services.BuildServiceProvider();
+                var extensionManager = serviceProvider.GetService<IExtensionManager>();
+
+                var expander = new ModuleViewLocationExpander(extensionManager.GetExtensions());
+   
                 options.ViewLocationExpanders.Add(expander);
 
                 var extensionLibraryService = services.BuildServiceProvider().GetService<IExtensionLibraryService>();
                 ((List<MetadataReference>)options.AdditionalCompilationReferences).AddRange(extensionLibraryService.MetadataReferences());
+
+                (serviceProvider as IDisposable)?.Dispose();
             });
 
             // Register the configuration object for modules to register options with it

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
    
                 options.ViewLocationExpanders.Add(expander);
 
-                var extensionLibraryService = services.BuildServiceProvider().GetService<IExtensionLibraryService>();
+                var extensionLibraryService = serviceProvider.GetService<IExtensionLibraryService>();
                 ((List<MetadataReference>)options.AdditionalCompilationReferences).AddRange(extensionLibraryService.MetadataReferences());
 
                 (serviceProvider as IDisposable)?.Dispose();

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -69,13 +69,10 @@ namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
 
             services.Configure<RazorViewEngineOptions>(configureOptions: options =>
             {
-                var serviceProvider = services.BuildServiceProvider();
-                var extensionManager = serviceProvider.GetService<IExtensionManager>();
-
-                var expander = new ModuleViewLocationExpander(extensionManager.GetExtensions());
-   
+                var expander = new ModuleViewLocationExpander();
                 options.ViewLocationExpanders.Add(expander);
 
+                var serviceProvider = services.BuildServiceProvider();
                 var extensionLibraryService = serviceProvider.GetService<IExtensionLibraryService>();
                 ((List<MetadataReference>)options.AdditionalCompilationReferences).AddRange(extensionLibraryService.MetadataReferences());
 

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -17,7 +16,6 @@ using Orchard.Environment.Shell.Descriptor.Models;
 using Orchard.Hosting;
 using Orchard.Hosting.Mvc.Filters;
 using Orchard.Hosting.Mvc.ModelBinding;
-using Orchard.Hosting.Mvc.Razor;
 using Orchard.Hosting.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
@@ -69,13 +67,9 @@ namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
 
             services.Configure<RazorViewEngineOptions>(configureOptions: options =>
             {
-                var expander = new ModuleViewLocationExpander();
-                options.ViewLocationExpanders.Add(expander);
-
                 var serviceProvider = services.BuildServiceProvider();
                 var extensionLibraryService = serviceProvider.GetService<IExtensionLibraryService>();
                 ((List<MetadataReference>)options.AdditionalCompilationReferences).AddRange(extensionLibraryService.MetadataReferences());
-
                 (serviceProvider as IDisposable)?.Dispose();
             });
 

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Mvc/Razor/ModuleViewLocationExpander.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Mvc/Razor/ModuleViewLocationExpander.cs
@@ -1,10 +1,26 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.Razor;
+using Orchard.Environment.Extensions;
 
 namespace Orchard.Hosting.Mvc.Razor
 {
     public class ModuleViewLocationExpander : IViewLocationExpander
     {
+        private readonly IEnumerable<IExtensionInfo> _extensions;
+
+        public ModuleViewLocationExpander() : this(new ExtensionInfoList(new List<IExtensionInfo>()))
+        {
+        }
+
+        public ModuleViewLocationExpander(IExtensionInfoList extensions)
+        {
+            _extensions = extensions.Features.Where(x => x.Id == x.Extension.Id)
+                .Select(x => x.Extension).Reverse();
+        }
+
         /// <inheritdoc />
         public void PopulateValues(ViewLocationExpanderContext context)
         {
@@ -16,8 +32,14 @@ namespace Orchard.Hosting.Mvc.Razor
         {
             var result = new List<string>();
 
-            result.Add("/Modules/{2}/Views/{1}/{0}.cshtml");
-            result.Add("/Modules/{2}/Views/Shared/{0}.cshtml");
+            foreach (var extension in _extensions)
+            {
+                var viewsPath = Path.Combine(Path.DirectorySeparatorChar + extension.SubPath,
+                    "Views", context.AreaName != extension.Id ? context.AreaName : String.Empty);
+
+                result.Add(Path.Combine(viewsPath, "{1}", "{0}.cshtml"));
+                result.Add(Path.Combine(viewsPath, "Shared", "{0}.cshtml"));
+            }
 
             result.AddRange(viewLocations);
 

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/project.json
@@ -10,7 +10,6 @@
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging": "1.1.0",
     "Microsoft.AspNetCore.Mvc.Modules.Abstractions": "1.0.0-*",
-    "Orchard.DisplayManagement": "2.0.0-*",
     "Orchard.Environment.Commands": "2.0.0-*",
     "Orchard.Environment.Extensions": "2.0.0-*",
     "Orchard.Hosting": "2.0.0-*"

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/project.json
@@ -10,6 +10,7 @@
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging": "1.1.0",
     "Microsoft.AspNetCore.Mvc.Modules.Abstractions": "1.0.0-*",
+    "Orchard.DisplayManagement": "2.0.0-*",
     "Orchard.Environment.Commands": "2.0.0-*",
     "Orchard.Environment.Extensions": "2.0.0-*",
     "Orchard.Hosting": "2.0.0-*"

--- a/src/Orchard.Cms.Web/DesignTimeMvcBuilderConfiguration.cs
+++ b/src/Orchard.Cms.Web/DesignTimeMvcBuilderConfiguration.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orchard.Environment.Extensions;
-using Orchard.Hosting.Mvc.Razor;
 
 namespace Orchard.Cms.Web
 {
@@ -31,9 +30,6 @@ namespace Orchard.Cms.Web
 
             builder.AddRazorOptions(options =>
             {
-                var expander = new ModuleViewLocationExpander();
-                options.ViewLocationExpanders.Add(expander);
-
                 var extensionLibraryService = services.BuildServiceProvider().GetService<IExtensionLibraryService>();
                 ((List<MetadataReference>)options.AdditionalCompilationReferences).AddRange(extensionLibraryService.MetadataReferences());
             });

--- a/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -74,7 +74,8 @@ namespace Orchard.DisplayManagement.Descriptors
                     BuildDescriptors(bindingStrategy, builtAlterations);
                 }
 
-                var enabledFeatureIds = _shellFeaturesManager.GetEnabledFeaturesAsync().Result.Select(fd => fd.Id).ToList();
+                var enabledFeatureIds = _shellFeaturesManager.GetEnabledFeaturesAsync()
+                    .GetAwaiter().GetResult().Select(f => f.Id).ToList();
 
                 var descriptors = _shapeDescriptors
                     .Where(sd => IsEnabledModuleOrRequestedTheme(sd.Value, themeId, enabledFeatureIds))
@@ -216,7 +217,7 @@ namespace Orchard.DisplayManagement.Descriptors
             // determine if the given feature is a base theme of the given theme
             var availableFeatures = _extensionManager.GetFeatures();
 
-            var themeFeature = availableFeatures.SingleOrDefault(fd => fd.Id == themeId);
+            var themeFeature = availableFeatures.SingleOrDefault(f => f.Id == themeId);
             while (themeFeature != null && themeFeature.Extension.Manifest.IsTheme())
             {
                 var themeExtensionInfo = new ThemeExtensionInfo(themeFeature.Extension);
@@ -228,7 +229,7 @@ namespace Orchard.DisplayManagement.Descriptors
                 {
                     return true;
                 }
-                themeFeature = availableFeatures.SingleOrDefault(fd => fd.Id == themeExtensionInfo.BaseTheme);
+                themeFeature = availableFeatures.SingleOrDefault(f => f.Id == themeExtensionInfo.BaseTheme);
             }
             return false;
         }

--- a/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -164,9 +164,7 @@ namespace Orchard.DisplayManagement.Descriptors
                 }
             }
 
-            return _extensionManager
-                .GetDependentFeatures(item.Value.Feature.Id)
-                .Contains(subject.Value.Feature);
+            return item.Value.Feature.Dependencies?.Contains(subject.Value.Feature.Id) ?? false;
         }
 
         private bool IsEnabledModuleOrRequestedTheme(FeatureShapeDescriptor descriptor, string themeName, List<string> enabledFeatureIds)

--- a/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
+++ b/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
@@ -17,7 +17,7 @@ namespace Orchard.DisplayManagement.Razor
         public void PopulateValues(ViewLocationExpanderContext context)
         {
             var themeManager = context.ActionContext.HttpContext.RequestServices.GetService<IThemeManager>();
-            context.Values["Theme"] = themeManager.GetThemeAsync().Result.Id;
+            context.Values["Theme"] = themeManager.GetThemeAsync().GetAwaiter().GetResult().Id;
         }
 
         /// <inheritdoc />
@@ -27,14 +27,14 @@ namespace Orchard.DisplayManagement.Razor
             var extensionManager = context.ActionContext.HttpContext.RequestServices.GetService<IExtensionManager>();
             var themeManager = context.ActionContext.HttpContext.RequestServices.GetService<IThemeManager>();
             var siteService = context.ActionContext.HttpContext.RequestServices.GetService<ISiteService>();
-            var site = siteService.GetSiteSettingsAsync().Result;
+            var site = siteService.GetSiteSettingsAsync().GetAwaiter().GetResult();
 
             var orderedFeatures = extensionManager.GetExtensions().Features;
             var orderedExtensions = orderedFeatures.Where(f => f.Id == f.Extension.Id).Select(f => f.Extension);
             var extension = orderedExtensions.FirstOrDefault(e => e.Id == context.AreaName);
 
             var themes = new List<IExtensionInfo>();
-            var currentTheme = themeManager.GetThemeAsync().Result;
+            var currentTheme = themeManager.GetThemeAsync().GetAwaiter().GetResult();
             var adminThemeId = (string)site.Properties["CurrentAdminThemeName"];
 
             themes.Add(currentTheme);

--- a/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
+++ b/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
@@ -29,7 +29,7 @@ namespace Orchard.DisplayManagement.Razor
             var siteService = context.ActionContext.HttpContext.RequestServices.GetService<ISiteService>();
             var site = siteService.GetSiteSettingsAsync().GetAwaiter().GetResult();
 
-            var orderedFeatures = extensionManager.GetExtensions().Features;
+            var orderedFeatures = extensionManager.GetFeatures();
             var orderedExtensions = orderedFeatures.Where(f => f.Id == f.Extension.Id).Select(f => f.Extension);
             var extension = orderedExtensions.FirstOrDefault(e => e.Id == context.AreaName);
 

--- a/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
+++ b/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
@@ -17,13 +17,6 @@ namespace Orchard.DisplayManagement.Razor
         /// <inheritdoc />
         public void PopulateValues(ViewLocationExpanderContext context)
         {
-            string test = "Test";
-            if (context.Values.ContainsKey("Test"))
-            {
-                test = test + "x";
-            }
-
-            context.Values["Test"] = test;
         }
 
         /// <inheritdoc />

--- a/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
+++ b/src/Orchard.DisplayManagement/Razor/ThemeAwareViewLocationExpander.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Orchard.DisplayManagement.Extensions;
 using Orchard.DisplayManagement.Theming;
 using Orchard.Environment.Extensions;
-using Orchard.Environment.Shell;
 using Orchard.Settings;
 
 namespace Orchard.DisplayManagement.Razor

--- a/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
+++ b/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
@@ -35,6 +35,8 @@ namespace Orchard.DisplayManagement
             services.Configure<RazorViewEngineOptions>(options =>
             {
                 options.FileProviders.Add(new ThemingFileProvider());
+                var expander = new ThemeAwareViewLocationExpander();
+                options.ViewLocationExpanders.Add(expander);
             });
 
             services.AddScoped<IFeatureBuilderEvents, ThemeFeatureBuilderEvents>();

--- a/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
+++ b/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
@@ -31,9 +31,6 @@ namespace Orchard.Environment.Shell
         public async Task<IEnumerable<IFeatureInfo>> GetEnabledFeaturesAsync()
         {
             var shellDescriptor = await GetCurrentShell();
-
-            // Because shellDescriptor.Features already contains all features and their dependencies
-            // So, as done in O1, here i think no need to call GetFeatures(string[] featureIdsToLoad)
             return _extensionManager.GetFeatures().Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id));
         }
 
@@ -50,9 +47,6 @@ namespace Orchard.Environment.Shell
         public async Task<IEnumerable<IFeatureInfo>> GetDisabledFeaturesAsync()
         {
             var shellDescriptor = await GetCurrentShell();
-
-            // Because shellDescriptor.Features already contains all features and their dependencies
-            // So, as done in O1, here i think no need to call GetFeatures(string[] featureIdsToLoad)
             return _extensionManager.GetFeatures().Where(f => shellDescriptor.Features.All(sf => sf.Id != f.Id));
         }
 

--- a/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
+++ b/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
@@ -1,10 +1,10 @@
-﻿using Orchard.Environment.Extensions;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orchard.Environment.Extensions;
 using Orchard.Environment.Extensions.Features;
 using Orchard.Environment.Shell.Descriptor;
 using Orchard.Environment.Shell.Descriptor.Models;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Linq;
 
 namespace Orchard.Environment.Shell
 {
@@ -32,8 +32,9 @@ namespace Orchard.Environment.Shell
         {
             var shellDescriptor = await GetCurrentShell();
 
-            return _extensionManager.GetFeatures(
-                shellDescriptor.Features.Select(x => x.Id).ToArray());
+            // Because shellDescriptor.Features already contains all features and their dependencies
+            // So, as done in O1, here i think no need to call GetFeatures(string[] featureIdsToLoad)
+            return _extensionManager.GetFeatures().Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id));
         }
 
         public async Task<IEnumerable<IFeatureInfo>> EnableFeaturesAsync(IEnumerable<IFeatureInfo> features)
@@ -50,12 +51,9 @@ namespace Orchard.Environment.Shell
         {
             var shellDescriptor = await GetCurrentShell();
 
-            var enabledFeatures = _extensionManager.GetFeatures(
-                shellDescriptor.Features.Select(x => x.Id).ToArray());
-
-            var allFeatures = _extensionManager.GetFeatures();
-
-            return allFeatures.Except(enabledFeatures);
+            // Because shellDescriptor.Features already contains all features and their dependencies
+            // So, as done in O1, here i think no need to call GetFeatures(string[] featureIdsToLoad)
+            return _extensionManager.GetFeatures().Where(f => shellDescriptor.Features.All(sf => sf.Id != f.Id));
         }
 
         public async Task<IEnumerable<IFeatureInfo>> DisableFeaturesAsync(IEnumerable<IFeatureInfo> features)


### PR DESCRIPTION
Fixes #376 


- We use `extension.SubPath` which contains `Modules or Themes` or another extension location..


- As an example, for a view component defined as below.

        \Modules\Orchard.ContentTypes\Views\Shared\Components\SelectContentTypes\Default.cshtml

- Can be overridden by one of the followings (through a module with higher priority or which depend on the above module, or by a theme if implicit dependencies are implemented)

      \Modules\Orchard.Demo\Views\Orchard.ContentTypes\Admin\Components\SelectContentTypes\Default.cshtml
      \Modules\Orchard.Demo\Views\Orchard.ContentTypes\Shared\Components\SelectContentType\Default.cshtml

- Here we assume we can override a controller view or component (not shapes) only through a main feature (which have the same id as its extension). Let me know if it is right.

- Otherwise, we would need to select all features, and, because sub features have different ids, dependencies and priorities, we would need others paths with segments related to sub feature ids

Best.