### PR TITLE
#388 CreateUser Command

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
@@ -35,16 +35,13 @@ namespace Orchard.Recipes.RecipeSteps
 
             foreach(var command in step.Commands)
             {
-                Logger.LogInformation("Executing command: {0}", command);
-                using (var memoryStream = new MemoryStream())
+                Logger.LogInformation("Executing command: {0}", command);                
+                using (var output = new StringWriter())
                 {
-                    using (var output = new StreamWriter(memoryStream))
-                    {
-                        var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));
-                        commandParameters.Output = output;
-                        _commandManager.ExecuteAsync(commandParameters);
-                        Logger.LogInformation("{0}", output);
-                    }
+                    var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));
+                    commandParameters.Output = output;
+                    _commandManager.ExecuteAsync(commandParameters);
+                    Logger.LogInformation("{0}", output);
                 }
                 Logger.LogInformation("Executed command: {0}", command);
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
@@ -29,7 +29,7 @@ namespace Orchard.Recipes.RecipeSteps
 
         public override string Name { get { return "Command"; } }
 
-        public override Task ExecuteAsync(RecipeExecutionContext context)
+        public override async Task ExecuteAsync(RecipeExecutionContext context)
         {
             var step = context.RecipeStep.Step.ToObject<InternalStep>();
 
@@ -40,13 +40,11 @@ namespace Orchard.Recipes.RecipeSteps
                 {
                     var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));
                     commandParameters.Output = output;
-                    _commandManager.ExecuteAsync(commandParameters);
+                    await _commandManager.ExecuteAsync(commandParameters);
                     Logger.LogInformation("{0}", output);
                 }
                 Logger.LogInformation("Executed command: {0}", command);
             }
-
-            return Task.CompletedTask;
         }
 
         private class InternalStep

--- a/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Recipes/RecipeSteps/CommandStep.cs
@@ -5,6 +5,7 @@ using Orchard.Environment.Commands;
 using Orchard.Environment.Commands.Parameters;
 using Orchard.Recipes.Models;
 using Orchard.Recipes.Services;
+using System.IO;
 
 namespace Orchard.Recipes.RecipeSteps
 {
@@ -35,11 +36,16 @@ namespace Orchard.Recipes.RecipeSteps
             foreach(var command in step.Commands)
             {
                 Logger.LogInformation("Executing command: {0}", command);
-
-                var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));
-
-                _commandManager.ExecuteAsync(commandParameters);
-
+                using (var memoryStream = new MemoryStream())
+                {
+                    using (var output = new StreamWriter(memoryStream))
+                    {
+                        var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));
+                        commandParameters.Output = output;
+                        _commandManager.ExecuteAsync(commandParameters);
+                        Logger.LogInformation("{0}", output);
+                    }
+                }
                 Logger.LogInformation("Executed command: {0}", command);
             }
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Controllers/SetupController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Controllers/SetupController.cs
@@ -124,8 +124,8 @@ namespace Orchard.Setup.Controllers
             {
                 SiteName = model.SiteName,
                 EnabledFeatures = null, // default list,
-                AdminUsername = model.AdminUserName,
-                AdminEmail = model.AdminEmail,
+                AdminUsername = model.UserName,
+                AdminEmail = model.Email,
                 AdminPassword = model.Password,
                 Errors = new Dictionary<string, string>(),
                 Recipe = selectedRecipe

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/ViewModels/SetupViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/ViewModels/SetupViewModel.cs
@@ -24,10 +24,10 @@ namespace Orchard.Setup.ViewModels
         public bool TablePrefixPreset { get; set; }
 
         [Required]
-        public string AdminUserName { get; set; }
+        public string UserName { get; set; }
 
         [EmailAddress]
-        public string AdminEmail { get; set; }
+        public string Email { get; set; }
 
         [DataType(DataType.Password)]
         public string Password { get; set; }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Views/Setup/Index.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Views/Setup/Index.cshtml
@@ -143,15 +143,15 @@
         <span class="text-muted form-text small">@T["The super user has all the rights. It should be used only during Setup and for disaster recovery."]</span>
     </h6>
     <div class="row">
-        <div class="form-group col-md-6" asp-validation-class-for="AdminUserName">
-            <label asp-for="AdminUserName">@T["User name"]</label>
-            <input asp-for="AdminUserName" class="form-control" />
-            <span asp-validation-for="AdminUserName" class="text-danger">@T["The user name is required."]</span>
+        <div class="form-group col-md-6" asp-validation-class-for="UserName">
+            <label asp-for="UserName">@T["User name"]</label>
+            <input asp-for="UserName" class="form-control" />
+            <span asp-validation-for="UserName" class="text-danger">@T["The user name is required."]</span>
         </div>
-        <div class="form-group col-md-6" asp-validation-class-for="AdminEmail">
-            <label for="AdminEmail">@T["Email"]</label>
-            <input asp-for="AdminEmail" class="form-control" type="email"/>
-            <span asp-validation-for="AdminEmail" class="text-danger">@T["The email is invalid."]</span>
+        <div class="form-group col-md-6" asp-validation-class-for="Email">
+            <label for="Email">@T["Email"]</label>
+            <input asp-for="Email" class="form-control" type="email"/>
+            <span asp-validation-for="Email" class="text-danger">@T["The email is invalid."]</span>
         </div>
     </div>
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Commands/UserCommands.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Commands/UserCommands.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Extensions.Localization;
+using Orchard.Environment.Commands;
+using Orchard.Users.Models;
+using Orchard.Users.Services;
+using System.Linq;
+using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orchard.Users.Commands
+{
+    public class UserCommands : DefaultCommandHandler
+    {
+        private readonly IUserService _userService;
+        
+        public UserCommands(IUserService userService,
+                            IStringLocalizer<UserCommands> localizer) : base(localizer)
+        {
+            _userService = userService;
+        }
+
+        [OrchardSwitch]
+        public string UserName { get; set; }
+
+        [OrchardSwitch]
+        public string Password { get; set; }
+
+        [OrchardSwitch]
+        public string Email { get; set; }
+
+        [OrchardSwitch]
+        public string Roles { get; set; }
+
+        [CommandName("createUser")]
+        [CommandHelp("createUser /UserName:<username> /Password:<password> /Email:<email> /Roles:{rolename,rolename,...}\r\n\t" + "Creates a new User")]
+        [OrchardSwitches("UserName,Password,Email")]
+        public void CreateUser()
+        {
+            var user = new User
+            {
+                UserName = UserName,
+                Email = Email,
+                RoleNames = (Roles ?? "").Split(new char[] {','}, StringSplitOptions.RemoveEmptyEntries).ToList()
+            };
+            if (_userService.CreateUserAsync(user, Password, (key, message) => Context.Output.WriteLine(message)).Result)
+                Context.Output.WriteLine(T["User created successfully"]);
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/IUserService.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/IUserService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Orchard.Users.Models;
+
+namespace Orchard.Users.Services
+{
+    public interface IUserService
+    {
+        Task<bool> CreateUserAsync(User user, string password, Action<string, string> reportError);
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/SetupEventHandler.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/SetupEventHandler.cs
@@ -27,11 +27,9 @@ namespace Orchard.Users.Services
             _serviceProvider = serviceProvider;
         }
 
-        public async Task Setup(string userName, string email, string password, Action<string, string> reportError)
+        public Task Setup(string userName, string email, string password, Action<string, string> reportError)
         {
-            var userManager = _serviceProvider.GetRequiredService<UserManager<User>>();
-            var options = _serviceProvider.GetRequiredService<IOptions<IdentityOptions>>().Value;
-            var T = _serviceProvider.GetRequiredService<IStringLocalizer<SetupEventHandler>>();
+            var userService = _serviceProvider.GetRequiredService<IUserService>();
 
             var superUser = new User
             {
@@ -40,51 +38,7 @@ namespace Orchard.Users.Services
                 RoleNames = { "Administrator" }
             };
 
-            var result = await userManager.CreateAsync(superUser, password);
-
-            if (!result.Succeeded)
-            {
-                foreach(var error in result.Errors)
-                {
-                    switch (error.Code)
-                    {
-                        // Password
-                        case "PasswordRequiresDigit":
-                            reportError("Password", T["Passwords must have at least one digit ('0'-'9')."]);
-                            break;
-                        case "PasswordRequiresLower":
-                            reportError("Password", T["Passwords must have at least one lowercase ('a'-'z')."]);
-                            break;
-                        case "PasswordRequiresUpper":
-                            reportError("Password", T["Passwords must have at least one uppercase('A'-'Z')."]);
-                            break;
-                        case "PasswordRequiresNonAlphanumeric":
-                            reportError("Password", T["Passwords must have at least one non letter or digit character."]);
-                            break;
-                        case "PasswordTooShort":
-                            reportError("Password", T["Passwords must be at least {0} characters.", options.Password.RequiredLength]);
-                            break;
-
-                        // Password confirmation
-                        case "PasswordMismatch":
-                            reportError("PasswordConfirmation", T["Incorrect password."]);
-                            break;
-
-                        // User name
-                        case "InvalidUserName":
-                            reportError("AdminUserName", T["User name '{0}' is invalid, can only contain letters or digits.", superUser]);
-                            break;
-
-                        // Email
-                        case "InvalidEmail":
-                            reportError("AdminEmail", T["Email '{0}' is invalid.", email]);
-                            break;
-                    }
-
-                }
-            }
-
-            return;
+            return userService.CreateUserAsync(superUser,password,reportError);
         }
     }
 }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
@@ -25,17 +25,17 @@ namespace Orchard.Users.Services
             bool result = true;
             if (string.IsNullOrWhiteSpace(user.UserName))
             {
-                reportError("UserName", T["You must provide an user name."]);
+                reportError("UserName", T["An user name is required."]);
                 result = false;
             }
             if (string.IsNullOrWhiteSpace(user.UserName))
             {
-                reportError("Password", T["You must provide a password."]);
+                reportError("Password", T["A password is required."]);
                 result = false;
             }
             if (string.IsNullOrWhiteSpace(user.Email))
             {
-                reportError("Email", T["You must provide an email."]);
+                reportError("Email", T["An email is required."]);
                 result = false;
             }
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Orchard.Users.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace Orchard.Users.Services
+{
+    public class UserService: IUserService
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly IOptions<IdentityOptions> _identityOptions;
+        private readonly IStringLocalizer<UserService> T;
+        public UserService(UserManager<User> userManager, IOptions<IdentityOptions> identityOptions, IStringLocalizer<UserService> stringLocalizer)
+        {
+            _userManager = userManager;
+            _identityOptions = identityOptions;
+            T = stringLocalizer;
+        }
+
+        public async Task<bool> CreateUserAsync(User user, string password, Action<string, string> reportError)
+        {
+            bool result = true;
+            if (string.IsNullOrWhiteSpace(user.UserName))
+            {
+                reportError("UserName", T["You must provide an user name."]);
+                result = false;
+            }
+            if (string.IsNullOrWhiteSpace(user.UserName))
+            {
+                reportError("Password", T["You must provide a password."]);
+                result = false;
+            }
+            if (string.IsNullOrWhiteSpace(user.Email))
+            {
+                reportError("Email", T["You must provide an email."]);
+                result = false;
+            }
+
+            if (!result)
+                return result;
+
+            if (await _userManager.FindByEmailAsync(user.Email) != null)
+            {
+                reportError(string.Empty, T["The email is already used."]);
+                return false;
+            }
+            
+            var identityResult = await _userManager.CreateAsync(user, password);
+            
+            if (!identityResult.Succeeded)
+            {
+                foreach (var error in identityResult.Errors)
+                {
+                    switch (error.Code)
+                    {
+                        // Password
+                        case "PasswordRequiresDigit":
+                            reportError("Password", T["Passwords must have at least one digit ('0'-'9')."]);
+                            break;
+                        case "PasswordRequiresLower":
+                            reportError("Password", T["Passwords must have at least one lowercase ('a'-'z')."]);
+                            break;
+                        case "PasswordRequiresUpper":
+                            reportError("Password", T["Passwords must have at least one uppercase('A'-'Z')."]);
+                            break;
+                        case "PasswordRequiresNonAlphanumeric":
+                            reportError("Password", T["Passwords must have at least one non letter or digit character."]);
+                            break;
+                        case "PasswordTooShort":
+                            reportError("Password", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
+                            break;
+
+                        // Password confirmation
+                        case "PasswordMismatch":
+                            reportError("PasswordConfirmation", T["Incorrect password."]);
+                            break;
+
+                        // User name
+                        case "InvalidUserName":
+                            reportError("UserName", T["User name '{0}' is invalid, can only contain letters or digits.", user.UserName]);
+                            break;
+                        case "DuplicateUserName":
+                            reportError("UserName", T["User name '{0}' is already used.", user.UserName]);
+                            break;
+
+                        // Email
+                        case "InvalidEmail":
+                            reportError("Email", T["Email '{0}' is invalid.", user.Email]);
+                            break;
+                        default:
+                            reportError(string.Empty, T["Unexpected error: '{0}'.", error.Code]);
+                            break;
+                    }
+                }
+            }
+
+            return identityResult.Succeeded;
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/UserService.cs
@@ -25,7 +25,7 @@ namespace Orchard.Users.Services
             bool result = true;
             if (string.IsNullOrWhiteSpace(user.UserName))
             {
-                reportError("UserName", T["An user name is required."]);
+                reportError("UserName", T["A user name is required."]);
                 result = false;
             }
             if (string.IsNullOrWhiteSpace(user.UserName))

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Startup.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Startup.cs
@@ -16,6 +16,8 @@ using Orchard.Users.Indexes;
 using Orchard.Users.Models;
 using Orchard.Users.Services;
 using YesSql.Core.Indexes;
+using Orchard.Users.Commands;
+using Orchard.Environment.Commands;
 
 namespace Orchard.Users
 {
@@ -79,8 +81,10 @@ namespace Orchard.Users
             services.AddScoped<IIndexProvider, UserIndexProvider>();
             services.AddScoped<IDataMigration, Migrations>();
 
+            services.AddScoped<IUserService, UserService>();
             services.AddScoped<SetupEventHandler>();
             services.AddScoped<ISetupEventHandler>(sp => sp.GetRequiredService<SetupEventHandler>());
+            services.AddScoped<ICommandHandler, UserCommands>();
 
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddScoped<INavigationProvider, AdminMenu>();

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Views/Admin/Create.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Views/Admin/Create.cshtml
@@ -7,12 +7,12 @@
 <form asp-action="Create" method="post">
     <div class="form-group" asp-validation-class-for="UserName">
         <label asp-for="UserName">@T["User name"]</label>
-        <span asp-validation-for="UserName" class="text-danger">@T["The user name is required."]</span>
+        <span asp-validation-for="UserName" class="text-danger"></span>
         <input asp-for="UserName" class="form-control" autofocus/>
     </div>
     <div class="form-group" asp-validation-class-for="Email">
         <label for="Email">@T["Email"]</label>
-        <span asp-validation-for="Email" class="text-danger">@T["The email is invalid."]</span>
+        <span asp-validation-for="Email" class="text-danger"></span>
         <input asp-for="Email" class="form-control" type="email" />
     </div>
     <div class="form-group" asp-validation-class-for="Password">

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/project.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/project.json
@@ -5,7 +5,8 @@
     "Microsoft.AspNetCore.Identity": "1.1.0",
     "Orchard.ContentManagement.Display": "2.0.0-*",
     "Orchard.Data.Abstractions": "2.0.0-*",
-    "Orchard.Environment.Navigation": "2.0.0-*"
+    "Orchard.Environment.Navigation": "2.0.0-*",
+    "Orchard.Environment.Commands": "2.0.0-*"
   },
   "buildOptions": {
     "define": [ "TRACE" ],


### PR DESCRIPTION
Adds the CreateUser command described on this issue: https://github.com/OrchardCMS/Orchard2/issues/388

To avoid repeated code validating data for a new user in Create User Command, in SetupEventHandler, in AccountController and in AdminController I refacored code moving this validation code to a new class called UserService.cs .
If do you agree with that we can also centralize in User service logic for validation and modification of an user that currently is done in AdminController.