### PR TITLE
Creating CommonPart to edit Owner and CreatedUtc

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
@@ -34,7 +34,7 @@ namespace Orchard.Autoroute.Settings
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
         {
-            if (!String.Equals("AutoroutePart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            if (!String.Equals(nameof(AutoroutePart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -351,8 +351,6 @@ namespace Orchard.Contents.Controllers
                 return Unauthorized();
             }
 
-            _contentManager.Create(contentItem, VersionOptions.Draft);
-
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this);
 
             if (!ModelState.IsValid)
@@ -360,6 +358,8 @@ namespace Orchard.Contents.Controllers
                 _session.Cancel();
                 return View(model);
             }
+
+            _contentManager.Create(contentItem, VersionOptions.Draft);
 
             await conditionallyPublish(contentItem);
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/DateEditorDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/DateEditorDriver.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Orchard.ContentManagement.Display.ContentDisplay;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Contents.Models;
+using Orchard.Contents.ViewModels;
+using Orchard.DisplayManagement.ModelBinding;
+using Orchard.DisplayManagement.Views;
+
+namespace Orchard.Contents.Drivers
+{
+    public class DateEditorDriver : ContentPartDisplayDriver<CommonPart>
+    {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+
+        public DateEditorDriver(IContentDefinitionManager contentDefinitionManager)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+        }
+
+        public override IDisplayResult Edit(CommonPart part)
+        {
+            var settings = GetSettings(part);
+
+            if (settings.DisplayDateEditor)
+            {
+                return Shape<DateEditorViewModel>("CommonPart_Edit__Date", model =>
+                {
+                    model.CreatedUtc = part.ContentItem.CreatedUtc;
+                });
+            }
+
+            return null;
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(CommonPart part, IUpdateModel updater)
+        {
+            var settings = GetSettings(part);
+
+            if (settings.DisplayDateEditor)
+            {
+                var model = new DateEditorViewModel();
+                await updater.TryUpdateModelAsync(model, Prefix);
+
+                part.ContentItem.CreatedUtc = model.CreatedUtc;
+            }
+
+            return Edit(part);
+        }
+
+        public CommonPartSettings GetSettings(CommonPart part)
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.PartDefinition.Name, "CommonPart", StringComparison.Ordinal));
+            return contentTypePartDefinition.GetSettings<CommonPartSettings>();
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/OwnerEditorDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/OwnerEditorDriver.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Orchard.ContentManagement.Display.ContentDisplay;
+using Orchard.ContentManagement.Display.Models;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Contents.Models;
+using Orchard.Contents.ViewModels;
+using Orchard.DisplayManagement.ModelBinding;
+using Orchard.DisplayManagement.Views;
+using Orchard.Security;
+
+namespace Orchard.Contents.Drivers
+{
+    public class OwnerEditorDriver : ContentPartDisplayDriver<CommonPart>
+    {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IAuthorizationService _authorizationService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public OwnerEditorDriver(
+            IContentDefinitionManager contentDefinitionManager,
+            IAuthorizationService authorizationService,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+            _authorizationService = authorizationService;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public override async Task<IDisplayResult> EditAsync(CommonPart part, BuildPartEditorContext context)
+        {
+            var currentUser = _httpContextAccessor.HttpContext?.User;
+
+            if (currentUser == null || !(await _authorizationService.AuthorizeAsync(currentUser, StandardPermissions.SiteOwner, part)))
+            {
+                return null;
+            }
+
+            var settings = GetSettings(part);
+
+            if (settings.DisplayOwnerEditor)
+            {
+                return Shape<OwnerEditorViewModel>("CommonPart_Edit__Owner", model =>
+                {
+                    model.Owner = part.ContentItem.Owner;
+                });
+            }
+
+            return null;
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(CommonPart part, BuildPartEditorContext context)
+        {
+            var currentUser = _httpContextAccessor.HttpContext?.User;
+
+            if (currentUser == null || !(await _authorizationService.AuthorizeAsync(currentUser, StandardPermissions.SiteOwner, part)))
+            {
+                return null;
+            }
+
+            var settings = GetSettings(part);
+
+            if (settings.DisplayOwnerEditor)
+            {
+                var model = new OwnerEditorViewModel();
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
+                part.ContentItem.Owner = model.Owner;
+            }
+
+            return await EditAsync(part, context);
+        }
+
+        public CommonPartSettings GetSettings(CommonPart part)
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.PartDefinition.Name, "CommonPart", StringComparison.Ordinal));
+            return contentTypePartDefinition.GetSettings<CommonPartSettings>();
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/OwnerEditorDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Drivers/OwnerEditorDriver.cs
@@ -67,7 +67,11 @@ namespace Orchard.Contents.Drivers
             {
                 var model = new OwnerEditorViewModel();
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
-                part.ContentItem.Owner = model.Owner;
+
+                if (!string.IsNullOrEmpty(part.ContentItem.Owner) || part.ContentItem.Number > 0)
+                {
+                    part.ContentItem.Owner = model.Owner;
+                }                
             }
 
             return await EditAsync(part, context);

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Indexing/DefaultContentIndexHandler.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Indexing/DefaultContentIndexHandler.cs
@@ -36,9 +36,16 @@ namespace Orchard.Contents.Indexing
                     DocumentIndexOptions.Store));
 
             context.DocumentIndex.Entries.Add(
-                "Content.ContentItem.ModifiedBy",
+                "Content.ContentItem.Owner",
                 new DocumentIndex.DocumentIndexEntry(
-                    context.ContentItem.ModifiedBy,
+                    context.ContentItem.Owner,
+                    DocumentIndex.Types.Text,
+                    DocumentIndexOptions.Store));
+
+            context.DocumentIndex.Entries.Add(
+                "Content.ContentItem.Author",
+                new DocumentIndex.DocumentIndexEntry(
+                    context.ContentItem.Author,
                     DocumentIndex.Types.Text,
                     DocumentIndexOptions.Store));
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Migrations.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Migrations.cs
@@ -1,0 +1,25 @@
+﻿using Orchard.ContentManagement.Metadata.Settings;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Data.Migration;
+
+namespace Orchard.Contents
+{
+    public class Migrations : DataMigration
+    {
+        IContentDefinitionManager _contentDefinitionManager;
+
+        public Migrations(IContentDefinitionManager contentDefinitionManager)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+        }
+
+        public int Create()
+        {
+            _contentDefinitionManager.AlterPartDefinition("CommonPart", builder => builder
+                .Attachable()
+                .WithDescription("Provides an editor for the common properties of a content item."));
+
+            return 1;
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Models/CommonPart.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Models/CommonPart.cs
@@ -1,0 +1,12 @@
+﻿using Orchard.ContentManagement;
+
+namespace Orchard.Contents.Models
+{
+    /// <summary>
+    /// When attached to a content type, provides a way to edit the common
+    /// properties of a content item like CreatedUtc and Owner.
+    /// </summary>
+    public class CommonPart : ContentPart
+    {
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Models/CommonPartSettings.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Models/CommonPartSettings.cs
@@ -1,0 +1,8 @@
+namespace Orchard.Contents.Models
+{
+    public class CommonPartSettings
+    {
+        public bool DisplayDateEditor { get; set; }
+        public bool DisplayOwnerEditor { get; set; }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Settings/CommonPartSettingsDisplayDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Settings/CommonPartSettingsDisplayDriver.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Orchard.ContentManagement.Metadata.Models;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Contents.Models;
+using Orchard.Contents.ViewModels;
+using Orchard.ContentTypes.Editors;
+using Orchard.DisplayManagement.ModelBinding;
+using Orchard.DisplayManagement.Views;
+
+namespace Orchard.Lists.Settings
+{
+    public class CommonPartSettingsDisplayDriver : ContentTypePartDisplayDriver
+    {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+
+        public CommonPartSettingsDisplayDriver(
+            IContentDefinitionManager contentDefinitionManager,
+            IStringLocalizer<CommonPartSettingsDisplayDriver> localizer)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+            TS = localizer;
+        }
+
+        public IStringLocalizer TS { get; set; }
+
+        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        {
+            if (!String.Equals("CommonPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return Shape<CommonPartSettingsViewModel>("CommonPartSettings_Edit", model =>
+            {
+                var settings = contentTypePartDefinition.GetSettings<CommonPartSettings>();
+                model.DisplayDateEditor = settings.DisplayDateEditor;
+                model.DisplayOwnerEditor = settings.DisplayOwnerEditor;
+
+                return Task.CompletedTask;
+            }).Location("Content");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
+        {
+            if (!String.Equals("CommonPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var model = new CommonPartSettingsViewModel();
+
+            if (await context.Updater.TryUpdateModelAsync(model, Prefix))
+            {
+                context.Builder.WithSettings(new CommonPartSettings { DisplayDateEditor = model.DisplayDateEditor, DisplayOwnerEditor = model.DisplayOwnerEditor});
+            }
+
+            return Edit(contentTypePartDefinition, context.Updater);
+        }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Settings/CommonPartSettingsDisplayDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Settings/CommonPartSettingsDisplayDriver.cs
@@ -27,7 +27,7 @@ namespace Orchard.Lists.Settings
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
-            if (!String.Equals("CommonPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            if (!String.Equals(nameof(CommonPart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }
@@ -44,7 +44,7 @@ namespace Orchard.Lists.Settings
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
         {
-            if (!String.Equals("CommonPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            if (!String.Equals(nameof(CommonPart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Startup.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Startup.cs
@@ -11,11 +11,15 @@ using Orchard.Contents.Drivers;
 using Orchard.Contents.Feeds.Builders;
 using Orchard.Contents.Handlers;
 using Orchard.Contents.Indexing;
+using Orchard.Contents.Models;
 using Orchard.Contents.Recipes;
+using Orchard.ContentTypes.Editors;
+using Orchard.Data.Migration;
 using Orchard.DisplayManagement.Descriptors;
 using Orchard.Environment.Navigation;
 using Orchard.Feeds;
 using Orchard.Indexing;
+using Orchard.Lists.Settings;
 using Orchard.Recipes;
 using Orchard.Scripting;
 using Orchard.Security.Permissions;
@@ -39,6 +43,13 @@ namespace Orchard.Contents
             services.AddScoped<IContentItemIndexHandler, DefaultContentIndexHandler>();
 
             services.AddScoped<IGlobalMethodProvider, IdGeneratorMethod>();
+            services.AddScoped<IDataMigration, Migrations>();
+
+            // Common Part
+            services.AddSingleton<ContentPart, CommonPart>();
+            services.AddScoped<IContentTypePartDefinitionDisplayDriver, CommonPartSettingsDisplayDriver>();
+            services.AddScoped<IContentPartDisplayDriver, DateEditorDriver>();
+            services.AddScoped<IContentPartDisplayDriver, OwnerEditorDriver>();
 
             // Feeds
             // TODO: Move to feature

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/CommonPartSettingsViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/CommonPartSettingsViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Orchard.Contents.ViewModels
+{
+    public class CommonPartSettingsViewModel
+    {
+        public bool DisplayDateEditor { get; set; }
+        public bool DisplayOwnerEditor { get; set; }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/DateEditorViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/DateEditorViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Orchard.Contents.ViewModels
+{
+    public class DateEditorViewModel
+    {
+        public DateTimeOffset? CreatedUtc { get; set; }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/OwnerEditorViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/OwnerEditorViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Orchard.Contents.ViewModels
+{
+    public class OwnerEditorViewModel
+    {
+        public string Owner { get; set; }
+    }
+}

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -1,0 +1,8 @@
+﻿@using Orchard.Contents.ViewModels;
+@model DateEditorViewModel
+
+<fieldset class="form-group" asp-validation-class-for="CreatedUtc">
+    <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
+    <input asp-for="CreatedUtc" class="form-control" />
+    <span class="hint">@T["The date when the content item was created or first publised."]</span>
+</fieldset>

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -4,5 +4,5 @@
 <fieldset class="form-group" asp-validation-class-for="CreatedUtc">
     <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
     <input asp-for="CreatedUtc" class="form-control" />
-    <span class="hint">@T["The date when the content item was created or first publised."]</span>
+    <span class="hint">@T["The date when the content item was created or first published."]</span>
 </fieldset>

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Owner.Edit.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPart-Owner.Edit.cshtml
@@ -1,0 +1,8 @@
+﻿@using Orchard.Contents.ViewModels;
+@model OwnerEditorViewModel
+
+<fieldset class="form-group" asp-validation-class-for="Owner">
+    <label asp-for="Owner">@T["Owner"] <span asp-validation-for="Owner"></span></label>
+    <input asp-for="Owner" class="form-control" />
+    <span class="hint">@T["The owner of the content item."]</span>
+</fieldset>

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPartSettings.Edit.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Views/CommonPartSettings.Edit.cshtml
@@ -1,0 +1,17 @@
+@model Orchard.Contents.ViewModels.CommonPartSettingsViewModel
+
+<fieldset class="form-group">
+    <div class="form-check">
+        <label class="form-check-label">
+            <input asp-for="DisplayDateEditor" type="checkbox" class="form-check-input" checked="@Model.DisplayDateEditor" /> @T["Display date editor"]
+            <span class="hint">@T["Check to be able to edit the creation date of the content item."]</span>
+        </label>
+    </div>
+
+    <div class="form-check">
+        <label class="form-check-label">
+            <input asp-for="DisplayOwnerEditor" type="checkbox" class="form-check-input" checked="@Model.DisplayOwnerEditor" /> @T["Display owner editor"]
+            <span class="hint">@T["Check to be able to edit the owner of the content item. The <code>SiteOwner</code> permission will also be required."]</span>
+        </label>
+    </div>
+</fieldset>

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/project.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/project.json
@@ -10,7 +10,7 @@
     "Orchard.Indexing.Abstractions": "2.0.0-*",
     "Orchard.Scripting.Abstractions": "2.0.0-*",
     "Orchard.Feeds.Abstractions": "2.0.0-*",
-    "Orchard.Recipes.Abstractions": "2.0.0-*"
+    "Orchard.Recipes.Abstractions": "2.0.0-*",
     "Orchard.ContentTypes.Abstractions": "2.0.0-*"
   },
   "buildOptions": {

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/project.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/project.json
@@ -11,6 +11,7 @@
     "Orchard.Scripting.Abstractions": "2.0.0-*",
     "Orchard.Feeds.Abstractions": "2.0.0-*",
     "Orchard.Recipes.Abstractions": "2.0.0-*"
+    "Orchard.ContentTypes.Abstractions": "2.0.0-*"
   },
   "buildOptions": {
     "debugType": "portable"

--- a/src/Orchard.Cms.Web/Modules/Orchard.Lists/Settings/ListPartSettingsDisplayDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Lists/Settings/ListPartSettingsDisplayDriver.cs
@@ -28,7 +28,7 @@ namespace Orchard.Lists.Settings
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
-            if (!String.Equals("ListPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            if (!String.Equals(nameof(ListPart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }
@@ -51,7 +51,7 @@ namespace Orchard.Lists.Settings
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
         {
-            if (!String.Equals("ListPart", contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            if (!String.Equals(nameof(ListPart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Roles/Permissions.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Roles/Permissions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Orchard.Security;
 using Orchard.Security.Permissions;
 
 namespace Orchard.Roles
@@ -12,7 +13,7 @@ namespace Orchard.Roles
         {
             return new[]
             {
-                ManageRoles, AssignRoles
+                ManageRoles, AssignRoles, StandardPermissions.SiteOwner
             };
         }
 
@@ -21,7 +22,7 @@ namespace Orchard.Roles
             return new[] {
                 new PermissionStereotype {
                     Name = "Administrator",
-                    Permissions = new[] { ManageRoles, AssignRoles }
+                    Permissions = new[] { ManageRoles, AssignRoles, StandardPermissions.SiteOwner }
                 },
             };
         }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/blog.recipe.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/blog.recipe.json
@@ -399,7 +399,8 @@
           "Latest": true,
           "Number": 1,
           "Published": true,
-          "ModifiedBy": "[js: parameters('AdminUsername')]",
+          "Owner": "[js: parameters('AdminUsername')]",
+          "Author": "[js: parameters('AdminUsername')]",
           "TitlePart": {
             "Title": "Blog"
           },
@@ -417,7 +418,8 @@
           "Latest": true,
           "Number": 1,
           "Published": true,
-          "ModifiedBy": "[js: parameters('AdminUsername')]",
+          "Owner": "[js: parameters('AdminUsername')]",
+          "Author": "[js: parameters('AdminUsername')]",
           "BlogPost": {
             "Subtitle": {
               "Text": "Problems look mighty small from 150 miles up"
@@ -445,7 +447,8 @@
           "ContentType": "Article",
           "Latest": true,
           "Published": true,
-          "ModifiedBy": "[js: parameters('AdminUsername')]",
+          "Owner": "[js: parameters('AdminUsername')]",
+          "Author": "[js: parameters('AdminUsername')]",
           "Article": {
             "Subtitle": {
               "Text": "This is what I do"

--- a/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/IUserService.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Users/Services/IUserService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
 using Orchard.Users.Models;
 
 namespace Orchard.Users.Services

--- a/src/Orchard.Cms.Web/Themes/TheBlogTheme/Views/Content-BlogPost.Summary.cshtml
+++ b/src/Orchard.Cms.Web/Themes/TheBlogTheme/Views/Content-BlogPost.Summary.cshtml
@@ -9,7 +9,7 @@
     </a>
     <p class="post-meta">
         @T["Posted by {0} on {1}", 
-            Html.Raw($"<a href=\"#\">{Model.ContentItem.ModifiedBy}</a>"), 
+            Html.Raw($"<a href=\"#\">{Model.ContentItem.Owner}</a>"), 
             (object)Model.ContentItem.CreatedUtc.ToString("MMMM dd, yyyy")]
     </p>
 

--- a/src/Orchard.Cms.Web/Themes/TheBlogTheme/Views/Content-BlogPost.cshtml
+++ b/src/Orchard.Cms.Web/Themes/TheBlogTheme/Views/Content-BlogPost.cshtml
@@ -12,7 +12,7 @@
                         </h2>
                         <span class="meta">
                             @T["Posted by {0} on {1}",
-                                Html.Raw($"<a href=\"#\">{Model.ContentItem.ModifiedBy}</a>"),
+                                Html.Raw($"<a href=\"#\">{Model.ContentItem.Owner}</a>"),
                                 (object)Model.ContentItem.CreatedUtc.ToString("MMMM dd, yyyy")]
                         </span>
                     </div>

--- a/src/Orchard.ContentManagement.Abstractions/ContentElement.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentElement.cs
@@ -25,7 +25,7 @@ namespace Orchard.ContentManagement
         internal JObject Data { get; set; }
 
         [JsonIgnore]
-        public ContentItem ContentItem { get; internal set; }
+        public ContentItem ContentItem { get; set; }
 
         /// <summary>
         /// Whether the content has a named property or not.

--- a/src/Orchard.ContentManagement.Abstractions/ContentItem.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentItem.cs
@@ -60,10 +60,15 @@ namespace Orchard.ContentManagement
         public DateTimeOffset? CreatedUtc { get; set; }
 
         /// <summary>
+        /// The name of the user who first created this content item version
+        /// and owns content rigths.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
         /// The name of the user who last modified this content item version.
         /// </summary>
-        public string ModifiedBy { get; set; }
+        public string Author { get; set; }
 
-        
     }
 }

--- a/src/Orchard.ContentManagement.Abstractions/ContentItemConverter.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentItemConverter.cs
@@ -21,7 +21,8 @@ namespace Orchard.ContentManagement
             o.Add(new JProperty(nameof(ContentItem.ModifiedUtc), contentItem.ModifiedUtc));
             o.Add(new JProperty(nameof(ContentItem.PublishedUtc), contentItem.PublishedUtc));
             o.Add(new JProperty(nameof(ContentItem.CreatedUtc), contentItem.CreatedUtc));
-            o.Add(new JProperty(nameof(ContentItem.ModifiedBy), contentItem.ModifiedBy));
+            o.Add(new JProperty(nameof(ContentItem.Owner), contentItem.Owner));
+            o.Add(new JProperty(nameof(ContentItem.Author), contentItem.Author));
 
             // Write all custom content properties
             o.Merge(contentItem.Data);
@@ -72,9 +73,13 @@ namespace Orchard.ContentManagement
                 {
                     contentItem.CreatedUtc = (DateTimeOffset?)p.Value;
                 }
-                else if (p.Name == nameof(ContentItem.ModifiedBy))
+                else if (p.Name == nameof(ContentItem.Author))
                 {
-                    contentItem.ModifiedBy = (string)p.Value;
+                    contentItem.Author = (string)p.Value;
+                }
+                else if (p.Name == nameof(ContentItem.Owner))
+                {
+                    contentItem.Owner = (string)p.Value;
                 }
                 else
                 {

--- a/src/Orchard.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
+++ b/src/Orchard.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
@@ -144,6 +144,7 @@ namespace Orchard.ContentManagement.Display
 
                 part = _contentPartFactory.CreateContentPart(typePartDefinition.Name) ?? new ContentPart();
                 part = (ContentPart)contentItem.Get(part.GetType(), typePartDefinition.Name) ?? part;
+                part.ContentItem = contentItem;
 
                 // Create a custom shape to render all the part shapes into it
                 dynamic typePartShape = context.ShapeFactory.Create("ContentPart_Edit", Arguments.Empty);
@@ -217,6 +218,7 @@ namespace Orchard.ContentManagement.Display
 
                 part = _contentPartFactory.CreateContentPart(typePartDefinition.Name) ?? new ContentPart();
                 part = (ContentPart)contentItem.Get(part.GetType(), typePartDefinition.Name) ?? part;
+                part.ContentItem = contentItem;
 
                 // Create a custom shape to render all the part shapes into it
                 dynamic typePartShape = context.ShapeFactory.Create("ContentPart_Edit", Arguments.Empty);

--- a/src/Orchard.ContentManagement/Handlers/ContentsHandler.cs
+++ b/src/Orchard.ContentManagement/Handlers/ContentsHandler.cs
@@ -14,14 +14,14 @@ namespace Orchard.ContentManagement.Handlers
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public override void Initializing(InitializingContentContext context)
+        public override void Creating(CreateContentContext context)
         {
             var utcNow = _clock.UtcNow;
             context.ContentItem.CreatedUtc = utcNow;
             context.ContentItem.ModifiedUtc = utcNow;
 
             var httpContext = _httpContextAccessor.HttpContext;
-            if (context.ContentItem.Owner != null && (httpContext?.User?.Identity?.IsAuthenticated ?? false))
+            if (context.ContentItem.Owner == null && (httpContext?.User?.Identity?.IsAuthenticated ?? false))
             {
                 context.ContentItem.Owner = httpContext.User.Identity.Name;
             }

--- a/src/Orchard.ContentManagement/Handlers/ContentsHandler.cs
+++ b/src/Orchard.ContentManagement/Handlers/ContentsHandler.cs
@@ -19,6 +19,12 @@ namespace Orchard.ContentManagement.Handlers
             var utcNow = _clock.UtcNow;
             context.ContentItem.CreatedUtc = utcNow;
             context.ContentItem.ModifiedUtc = utcNow;
+
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (context.ContentItem.Owner != null && (httpContext?.User?.Identity?.IsAuthenticated ?? false))
+            {
+                context.ContentItem.Owner = httpContext.User.Identity.Name;
+            }
         }
 
         public override void Updating(UpdateContentContext context)
@@ -28,7 +34,9 @@ namespace Orchard.ContentManagement.Handlers
             var httpContext = _httpContextAccessor.HttpContext;
             if (httpContext?.User?.Identity?.IsAuthenticated ?? false)
             {
-                context.ContentItem.ModifiedBy = httpContext.User.Identity.Name;
+                // The value is only modified during update so that another event like
+                // publishing in a Workflow doesn't change it.
+                context.ContentItem.Author = httpContext.User.Identity.Name;
             }
         }
 

--- a/src/Orchard.ContentManagement/IdGenerator.cs
+++ b/src/Orchard.ContentManagement/IdGenerator.cs
@@ -10,9 +10,10 @@ namespace Orchard.ContentManagement
         public string GenerateUniqueId(ContentItem contentItem)
         {
             // Generate a base32 Guid value
-            var guid = Guid.NewGuid().ToString("N");
-            var hs = Convert.ToInt64(guid.Substring(0, 16), 16);
-            var ls = Convert.ToInt64(guid.Substring(16, 16), 16);
+            var guid = Guid.NewGuid().ToByteArray();
+
+            var hs = BitConverter.ToInt64(guid, 0);
+            var ls = BitConverter.ToInt64(guid, 8);
 
             return ToBase32(hs, ls);
         }

--- a/src/Orchard.ContentManagement/Records/ContentItemIndex.cs
+++ b/src/Orchard.ContentManagement/Records/ContentItemIndex.cs
@@ -14,6 +14,8 @@ namespace Orchard.ContentManagement.Records
         public DateTimeOffset? ModifiedUtc { get; set; }
         public DateTimeOffset? PublishedUtc { get; set; }
         public DateTimeOffset? CreatedUtc { get; set; }
+        public string Owner { get; set; }
+        public string Author { get; set; }
     }
 
     public class ContentItemIndexProvider : IndexProvider<ContentItem>
@@ -30,7 +32,9 @@ namespace Orchard.ContentManagement.Records
                     ContentItemId = contentItem.ContentItemId,
                     ModifiedUtc = contentItem.ModifiedUtc,
                     PublishedUtc = contentItem.PublishedUtc,
-                    CreatedUtc = contentItem.CreatedUtc
+                    CreatedUtc = contentItem.CreatedUtc,
+                    Owner = contentItem.Owner,
+                    Author = contentItem.Author
                 });
         }
     }

--- a/src/Orchard.ContentManagement/Records/Migrations.cs
+++ b/src/Orchard.ContentManagement/Records/Migrations.cs
@@ -13,13 +13,15 @@ namespace Orchard.ContentManagement.Records
                 .Column<int>("Number")
                 .Column<int>("Published")
                 .Column<string>("ContentType", column => column.WithLength(255))
-                .Column<DateTime>("ModifiedUtc", column => column.WithLength(255).Nullable())
-                .Column<DateTime>("PublishedUtc", column => column.WithLength(255).Nullable())
-                .Column<DateTime>("CreatedUtc", column => column.WithLength(255).Nullable())
+                .Column<DateTime>("ModifiedUtc", column => column.Nullable())
+                .Column<DateTime>("PublishedUtc", column => column.Nullable())
+                .Column<DateTime>("CreatedUtc", column => column.Nullable())
+                .Column<string>("Owner", column => column.WithLength(255).Nullable())
+                .Column<string>("Author", column => column.WithLength(255).Nullable())
             );
 
             SchemaBuilder.AlterTable(nameof(ContentItemIndex), table => table
-                .CreateIndex("IDX_ContentItemIndex_ContentItemId", "ContentItemId", "Latest", "Published")
+                .CreateIndex("IDX_ContentItemIndex_ContentItemId", "ContentItemId", "Latest", "Published", "CreatedUtc")
             );
 
             return 1;


### PR DESCRIPTION
Adding `ContentItem.Owner` and `ContentItem.Author`.
Adding `CommonPart` to enable `CreatedUtc` and `Owner` editors.