### PR TITLE
HotFix for DefaultCommandManager.MatchCommands

### DIFF
--- a/src/Orchard.Environment.Commands/DefaultCommandManager.cs
+++ b/src/Orchard.Environment.Commands/DefaultCommandManager.cs
@@ -67,7 +67,7 @@ namespace Orchard.Environment.Commands
                     // We check here number of arguments a command can recieve against
                     // arguments provided for the command to identify the correct command
                     // and avoid matching multiple commands.
-                    if(commandDescriptor.MethodInfo.GetParameters().Length == argCount - names.Count())
+                    if (names[0] == parameters.Arguments.First() && commandDescriptor.MethodInfo.GetParameters().Length == argCount - names.Count())
                     {
                         names = parameters.Arguments.ToArray();
                     }

--- a/src/Orchard.Environment.Commands/DefaultCommandManager.cs
+++ b/src/Orchard.Environment.Commands/DefaultCommandManager.cs
@@ -64,10 +64,11 @@ namespace Orchard.Environment.Commands
                 foreach (var name in commandDescriptor.Names)
                 {
                     var names = name.Split(' ');
+                    var namesCount = names.Count();
                     // We check here number of arguments a command can recieve against
                     // arguments provided for the command to identify the correct command
                     // and avoid matching multiple commands.
-                    if (name == string.Join(" ", parameters.Arguments.Take(names.Count())) && commandDescriptor.MethodInfo.GetParameters().Length == argCount - names.Count())
+                    if (name == string.Join(" ", parameters.Arguments.Take(namesCount)) && commandDescriptor.MethodInfo.GetParameters().Length == argCount - namesCount)
                     {
                         names = parameters.Arguments.ToArray();
                     }

--- a/src/Orchard.Environment.Commands/DefaultCommandManager.cs
+++ b/src/Orchard.Environment.Commands/DefaultCommandManager.cs
@@ -67,7 +67,7 @@ namespace Orchard.Environment.Commands
                     // We check here number of arguments a command can recieve against
                     // arguments provided for the command to identify the correct command
                     // and avoid matching multiple commands.
-                    if (names[0] == parameters.Arguments.First() && commandDescriptor.MethodInfo.GetParameters().Length == argCount - names.Count())
+                    if (name == string.Join(" ", parameters.Arguments.Take(names.Count())) && commandDescriptor.MethodInfo.GetParameters().Length == argCount - names.Count())
                     {
                         names = parameters.Arguments.ToArray();
                     }


### PR DESCRIPTION
Previous code doesn't compare command name of the descriptor with the command name to execute before comparing the number of arguments. It caused a different command is matched just because number of arguments is the same despite it is not the same command.