### PR TITLE
#503: Add IUpdateModel to UpdateContentContext.

### DIFF
--- a/src/Orchard.ContentManagement.Abstractions/Handlers/UpdateContentContext.cs
+++ b/src/Orchard.ContentManagement.Abstractions/Handlers/UpdateContentContext.cs
@@ -1,12 +1,16 @@
+using Orchard.DisplayManagement.ModelBinding;
+
 namespace Orchard.ContentManagement.Handlers
 {
     public class UpdateContentContext : ContentContextBase
     {
-        public UpdateContentContext(ContentItem contentItem) : base(contentItem)
+        public UpdateContentContext(ContentItem contentItem, IUpdateModel updater) : base(contentItem)
         {
             UpdatingItem = contentItem;
+            Updater = updater;
         }
 
         public ContentItem UpdatingItem { get; set; }
+        public IUpdateModel Updater { get; }
     }
 }

--- a/src/Orchard.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/Orchard.ContentManagement.Display/ContentDisplayManager.cs
@@ -162,7 +162,7 @@ namespace Orchard.ContentManagement.Display
 
             await BindPlacementAsync(context);
 
-            var updateContentContext = new UpdateContentContext(contentItem);
+            var updateContentContext = new UpdateContentContext(contentItem, updater);
 
             _contentHandlers.Invoke(handler => handler.Updating(updateContentContext), Logger);
 


### PR DESCRIPTION
Fixes #503 

Allow handlers to check in their Updated() event if the model is still valid (knowing that here all UpdateEditorAsync() have been called), this e.g to prevent from doing some specific db operations.

Best.