### PR TITLE
Use "App_Data" in place of "app_data".

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Mvc.Modules.Hosting
                 internalServices.AddOptions();
                 internalServices.AddLocalization();
                 internalServices.AddHostCore();
-                internalServices.AddExtensionManagerHost("app_data", "dependencies");
+                internalServices.AddExtensionManagerHost("App_Data", "dependencies");
                 internalServices.AddCommands();
 
                 internalServices.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();


### PR DESCRIPTION
@Jetski5822 said to me that we need to support environments where files systems are case sensitive.

So, when we check for a path we have the choice but at least we need to respect the case when we create a folder. Currently, when we delete `App_Data` folder, a new `app_data` folder is created with lower cases.