### PR TITLE
Fixes NRE when ownedPart exists and has no field.

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Controllers/AdminController.cs
@@ -183,7 +183,7 @@ namespace Orchard.ContentTypes.Controllers
             else
             {
                 var ownedPartDefinition = _contentDefinitionManager.GetPartDefinition(contentTypeDefinition.Name);
-                if (ownedPartDefinition != null)
+                if (ownedPartDefinition != null && viewModel.OrderedFieldNames != null)
                 {
                     _contentDefinitionService.AlterPartFieldsOrder(ownedPartDefinition, viewModel.OrderedFieldNames);
                 }


### PR DESCRIPTION
The NRE occurs when you save a content type which has an owned part but without any field.

The owned part is the one which has the same name as the type and which is created when you first add a field. On setup this owned part is created for the Page type through the recipe, but without any field.

Repro1

- Fresh setup on last master
- Edit Page content type and save

Repro2

- Edit any content type.
- If there is no field, add a field and save.
- Remove all fields and save.

Best.