### PR TITLE
Start working on the Versionable option.

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
@@ -17,6 +17,7 @@ namespace Orchard.ContentTypes.Editors
                 model.Creatable = settings.Creatable;
                 model.Listable = settings.Listable;
                 model.Draftable = settings.Draftable;
+                model.Versionable = settings.Versionable;
                 model.Securable = settings.Securable;
                 model.Stereotype = settings.Stereotype;
 
@@ -33,6 +34,7 @@ namespace Orchard.ContentTypes.Editors
                 context.Builder.Creatable(model.Creatable);
                 context.Builder.Listable(model.Listable);
                 context.Builder.Draftable(model.Draftable);
+                context.Builder.Versionable(model.Versionable);
                 context.Builder.Securable(model.Securable);
                 context.Builder.Stereotype(model.Stereotype);
             }

--- a/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
@@ -5,6 +5,7 @@
         public bool Creatable { get; set; }
         public bool Listable { get; set; }
         public bool Draftable { get; set; }
+        public bool Versionable { get; set; }
         public bool Securable { get; set; }
         public string Stereotype { get; set; }
     }

--- a/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/Orchard.Cms.Web/Modules/Orchard.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -25,6 +25,14 @@
 </fieldset>
 
 <fieldset class="form-group">
+    <label asp-for="Versionable">
+        <input asp-for="Versionable" type="checkbox">
+        @T["Versionable"]
+        <span class="hint">@T["Determines if this content type supports multiple versions."]</span>
+    </label>
+</fieldset>
+
+<fieldset class="form-group">
     <label asp-for="Securable">
         <input asp-for="Securable" type="checkbox">
         @T["Securable"]

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/Controllers/AdminController.cs
@@ -478,27 +478,7 @@ namespace Orchard.Contents.Controllers
             ContentTypeDefinition typeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
             var versionable = typeDefinition.Settings.ToObject<ContentTypeSettings>().Versionable;
 
-            if (!versionable && (contentItem.Published == saveDraft))
-            {
-                var nextVersion = VersionOptions.Number(contentItem.Number + 1);
-                var version = contentItem.Published ? nextVersion : VersionOptions.Published;
-                var prevVersion = VersionOptions.Number(contentItem.Number - 1);
-
-                var existingVersion = await _contentManager.GetAsync(contentItemId, version)
-                    ?? await _contentManager.GetAsync(contentItemId, prevVersion);
-
-                if (existingVersion != null)
-                {
-                    contentItem.Latest = false;
-                    _session.Save(contentItem);
-                    existingVersion.Latest = true;
-                    contentItem = existingVersion;
-                }
-            }
-
-            var draftRequired = contentItem.Published && (saveDraft || versionable);
-
-            if (draftRequired)
+            if (contentItem.Published && (saveDraft || versionable))
             {
                 contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.DraftRequired);
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/blog.recipe.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/blog.recipe.json
@@ -86,6 +86,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null
@@ -151,6 +152,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": null
@@ -216,6 +218,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/cms.recipe.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/cms.recipe.json
@@ -77,6 +77,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null

--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -141,6 +141,11 @@ namespace Orchard.ContentManagement
             return content.ContentItem != null && content.ContentItem.Published;
         }
 
+        public static bool IsLatest(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Latest;
+        }
+
         /// <summary>
         /// Whether the content element has a draft or not.
         /// </summary>

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -57,7 +57,7 @@ namespace Orchard.ContentManagement
         /// </summary>
         /// <param name="contentItem"></param>
         Task DiscardDraftAsync(ContentItem contentItem);
-        Task PublishAsync(ContentItem contentItem);
+        Task PublishAsync(ContentItem contentItem, bool versionable = true);
         Task UnpublishAsync(ContentItem contentItem);
         TAspect PopulateAspect<TAspect>(IContent content, TAspect aspect);
     }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -57,7 +57,7 @@ namespace Orchard.ContentManagement
         /// </summary>
         /// <param name="contentItem"></param>
         Task DiscardDraftAsync(ContentItem contentItem);
-        Task PublishAsync(ContentItem contentItem, bool versionable = true);
+        Task PublishAsync(ContentItem contentItem);
         Task UnpublishAsync(ContentItem contentItem);
         TAspect PopulateAspect<TAspect>(IContent content, TAspect aspect);
     }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManager.cs
@@ -103,6 +103,11 @@ namespace Orchard.ContentManagement
         public static VersionOptions DraftRequired { get { return new VersionOptions { IsDraft = true, IsDraftRequired = true }; } }
 
         /// <summary>
+        /// Gets the latest version and gets or creates a stage version based on it.
+        /// </summary>
+        public static VersionOptions StageRequired { get { return new VersionOptions { IsDraft = true, IsDraftRequired = true, IsStageRequired = true }; } }
+
+        /// <summary>
         /// Gets all versions.
         /// </summary>
         public static VersionOptions AllVersions { get { return new VersionOptions { IsAllVersions = true }; } }
@@ -126,6 +131,7 @@ namespace Orchard.ContentManagement
         public bool IsPublished { get; private set; }
         public bool IsDraft { get; private set; }
         public bool IsDraftRequired { get; private set; }
+        public bool IsStageRequired { get; private set; }
         public bool IsAllVersions { get; private set; }
         public int VersionNumber { get; private set; }
         public int VersionRecordId { get; private set; }

--- a/src/Orchard.ContentManagement.Abstractions/IContentManagerSession.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManagerSession.cs
@@ -8,6 +8,7 @@ namespace Orchard.ContentManagement
         bool RecallVersionId(int id, out ContentItem item);
         bool RecallContentItemId(string id, int version, out ContentItem item);
         bool RecallPublishedItemId(string id, out ContentItem item);
+        bool RecallLatestItemId(string id, out ContentItem item);
 
         void Clear();
     }

--- a/src/Orchard.ContentManagement.Abstractions/MetaData/Settings/ContentTypeSettings.cs
+++ b/src/Orchard.ContentManagement.Abstractions/MetaData/Settings/ContentTypeSettings.cs
@@ -15,6 +15,10 @@
         /// </summary>
         public bool Draftable { get; set; }
         /// <summary>
+        /// Used to determine if this content type supports mutiple versions
+        /// </summary>
+        public bool Versionable { get; set; }
+        /// <summary>
         /// Defines the stereotype of the type
         /// </summary>
         public string Stereotype { get; set; }

--- a/src/Orchard.ContentManagement.Abstractions/MetaData/Settings/ContentTypeSettingsExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/MetaData/Settings/ContentTypeSettingsExtensions.cs
@@ -20,6 +20,11 @@ namespace Orchard.ContentManagement.Metadata.Settings
             return builder.WithSetting("Draftable", draftable.ToString());
         }
 
+        public static ContentTypeDefinitionBuilder Versionable(this ContentTypeDefinitionBuilder builder, bool versionable = true)
+        {
+            return builder.WithSetting("Versionable", versionable.ToString());
+        }
+
         public static ContentTypeDefinitionBuilder Securable(this ContentTypeDefinitionBuilder builder, bool securable = true)
         {
             return builder.WithSetting("Securable", securable.ToString());

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -234,15 +234,8 @@ namespace Orchard.ContentManagement
 
             if (previous != null)
             {
-                if (!versionable)
-                {
-                    _session.Delete(previous);
-                }
-                else
-                {
-                    _session.Save(previous);
-                    previous.Published = false;
-                }
+                _session.Save(previous);
+                previous.Published = false;
             }
 
             contentItem.Published = true;
@@ -250,6 +243,11 @@ namespace Orchard.ContentManagement
             _session.Save(contentItem);
 
             Handlers.Reverse().Invoke(handler => handler.Published(context), _logger);
+
+            if (previous != null && !versionable)
+            {
+                _session.Delete(previous);
+            }
         }
 
         public async Task UnpublishAsync(ContentItem contentItem)

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -207,7 +207,7 @@ namespace Orchard.ContentManagement
             return contentItem;
         }
 
-        public async Task PublishAsync(ContentItem contentItem)
+        public async Task PublishAsync(ContentItem contentItem, bool versionable = true)
         {
             if (contentItem.Published)
             {
@@ -234,8 +234,15 @@ namespace Orchard.ContentManagement
 
             if (previous != null)
             {
-                _session.Save(previous);
-                previous.Published = false;
+                if (!versionable)
+                {
+                    _session.Delete(previous);
+                }
+                else
+                {
+                    _session.Save(previous);
+                    previous.Published = false;
+                }
             }
 
             contentItem.Published = true;

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -151,7 +151,7 @@ namespace Orchard.ContentManagement
             {
                 // If the published version is requested and is already loaded, we can
                 // return it right away
-                if(_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
+                if (_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
                 {
                     return contentItem;
                 }
@@ -207,7 +207,7 @@ namespace Orchard.ContentManagement
             return contentItem;
         }
 
-        public async Task PublishAsync(ContentItem contentItem, bool versionable = true)
+        public async Task PublishAsync(ContentItem contentItem)
         {
             if (contentItem.Published)
             {
@@ -243,11 +243,6 @@ namespace Orchard.ContentManagement
             _session.Save(contentItem);
 
             Handlers.Reverse().Invoke(handler => handler.Published(context), _logger);
-
-            if (previous != null && !versionable)
-            {
-                _session.Delete(previous);
-            }
         }
 
         public async Task UnpublishAsync(ContentItem contentItem)
@@ -287,7 +282,7 @@ namespace Orchard.ContentManagement
             Handlers.Invoke(handler => handler.Unpublishing(context), _logger);
 
             publishedItem.Published = false;
-            
+
             _session.Save(publishedItem);
 
             Handlers.Reverse().Invoke(handler => handler.Unpublished(context), _logger);


### PR DESCRIPTION
Just defined the `Versionable` option, then the goal will be.

1. `Draftable - Versionable` as already implemented where we can `Save` / `Publish` the new draft version.

2. `Not Draftable - Versionable` as already implemented where we can only `Publish` the temporary draft.

3. `Not Draftable - Not Versionable`. Here we will update directly the latest published item without creating a new draft (so no new version). Here i think we can keep `Publish` for the only one button because, even the item is already published, we are still "publishing" new data.

4. `Draftable and Not Versionable`. Here we would need to save a draft as before.

    a) Then when publishing a draft, as proposed by Sebastien, we could hard delete the previous published version. Here we would need to know (in the shared `EditPost()`) we are in the context of a `Publish`.

    b) When editing and publishing an already published item, we could do as for 3. but here also we would need to know we are in the context of a `Publish` action.

    Not sure it's good to create then hard delete versions, so one suggestion would be to only implement b). Then, if you only use `Publish` you will not create versions, only if you `Save` and `Publish` a draft. Here we still need to know we are in the context of a `Publish` action or create 2 `EditPost()`.

    **So, let me know** if it is worth to implement b), or just implement a), or maybe just not implement 4.

**Question**: can we safely hard delete a version in O2?

Best.