### PR TITLE
Fixes BuildNewVersionAsync() and DiscardDraftAsync().

### DIFF
--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -148,9 +148,7 @@ namespace Orchard.ContentManagement
         /// <returns><c>True</c> if the content has a draft, <c>False</c> otherwise.</returns>
         public static bool HasDraft(this IContent content)
         {
-            return content.ContentItem != null &&
-                   (content.ContentItem.Published == false ||
-                   content.ContentItem.Latest == false);
+            return content.ContentItem != null && (!content.ContentItem.Published || !content.ContentItem.Latest);
         }
 
         public static bool IsNew(this IContent content)

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using Orchard.ContentManagement.Handlers;
 using Orchard.ContentManagement.Metadata.Builders;
 using Orchard.ContentManagement.MetaData;
@@ -311,7 +312,7 @@ namespace Orchard.ContentManagement
 
             buildingContentItem.ContentItemId = existingContentItem.ContentItemId;
             buildingContentItem.Latest = true;
-            buildingContentItem.Data = existingContentItem.Data;
+            buildingContentItem.Data = new JObject(existingContentItem.Data);
 
             var context = new VersionContentContext(existingContentItem, buildingContentItem);
 
@@ -419,6 +420,14 @@ namespace Orchard.ContentManagement
             _session.Save(contentItem);
 
             Handlers.Reverse().Invoke(handler => handler.Removed(context), _logger);
+
+            var publishedItem = GetAsync(contentItem.ContentItemId, VersionOptions.Published).GetAwaiter().GetResult();
+
+            if (publishedItem != null)
+            {
+                publishedItem.Latest = true;
+                _session.Save(publishedItem);
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -405,7 +405,7 @@ namespace Orchard.ContentManagement
             Handlers.Reverse().Invoke(handler => handler.Removed(context), _logger);
         }
 
-        public Task DiscardDraftAsync(ContentItem contentItem)
+        public async Task DiscardDraftAsync(ContentItem contentItem)
         {
             if (contentItem.Published || !contentItem.Latest)
             {
@@ -421,15 +421,13 @@ namespace Orchard.ContentManagement
 
             Handlers.Reverse().Invoke(handler => handler.Removed(context), _logger);
 
-            var publishedItem = GetAsync(contentItem.ContentItemId, VersionOptions.Published).GetAwaiter().GetResult();
+            var publishedItem = await GetAsync(contentItem.ContentItemId, VersionOptions.Published);
 
             if (publishedItem != null)
             {
                 publishedItem.Latest = true;
                 _session.Save(publishedItem);
             }
-
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Repro of the 1st issue.

- Edit a page, then publish it to make the latest item published.
- Then update the content of the page and save it as a draft.
- Then view the published item, it has the draft content.

Fix of the 1st issue

- The new draft version reference the same Data object, so the published item was also updated. The fix was to create a `new JObject(existingContentItem.Data)`.

Repro of the 2nd issue.

- Edit a page which is already published (or publish it)
- Then update the content of the page and save it as a draft.
- So, now the latest item is the draft version.
- Then Go to the admin item list and do `Discard Draft`.
- Then, the page is no more in the list, even it has a published version.

Fix of the 2nd issue

- When the draft is the latest and discarded, there is no more latest version, so nothing is displayed in the list. The fix, when discarding the draft, was to make the published item (if it exits) the latest.

**UPDATE**: Same changes are in the versionable branch #531 where i needed it for testing.

Best.