### PR TITLE
Allowing behavior: hide on checkbox checked 

### DIFF
--- a/src/Orchard.Cms.Web/Themes/TheAdmin/Assets/js/admin.js
+++ b/src/Orchard.Cms.Web/Themes/TheAdmin/Assets/js/admin.js
@@ -88,6 +88,29 @@ $(function () {
     });
 });
 
+$(function () {
+    $('input[data-toggle="collapse in"]').each(function () {
+        // Prevent bootstrap from altering its behavior
+        // c.f. https://github.com/twbs/bootstrap/issues/21079
+        $(this).removeAttr("data-toggle");
+
+        // Expand the section if necessary
+        var target = $($(this).data('target'));
+        if (!$(this).prop('checked')) {
+            target.addClass('in');
+        }
+
+        $(this).on('change', function (e) {
+            // During a double-click, ignore state changes while the element is collapsing
+            if (target.hasClass('collapsing')) {
+                console.log('collapsing');
+                $(this).prop('checked', !$(this).prop('checked'));
+            }
+            target.collapse($(this).prop('checked') ? 'hide' : 'show');
+        });
+    });
+});
+
 function getTechnicalName(name){
     var result = "", c;
 


### PR DESCRIPTION
Solves this issue https://github.com/OrchardCMS/Orchard2/issues/518

Now a checkbox can be set to collapse sth when it is checked setting its attribute `data-toggle="collapse in"`

So, in the sample mentioned in the issue, the desired behaviour is accomplished in this way:
`<input asp-for="TestingModeEnabled" type="checkbox" data-toggle="collapse in" data-target="#certArea" class="form-check-input" checked="@Model.TestingModeEnabled"/>`