### PR TITLE
More checking and RecallLatestItemId() in content manager session.

### DIFF
--- a/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentExtensions.cs
@@ -142,6 +142,16 @@ namespace Orchard.ContentManagement
         }
 
         /// <summary>
+        /// Whether the content element is the latest or not.
+        /// </summary>
+        /// <param name="content">The content to check.</param>
+        /// <returns><c>True</c> if the content is the latest, <c>False</c> otherwise.</returns>
+        public static bool IsLatest(this IContent content)
+        {
+            return content.ContentItem != null && content.ContentItem.Latest;
+        }
+
+        /// <summary>
         /// Whether the content element has a draft or not.
         /// </summary>
         /// <param name="content">The content to check.</param>

--- a/src/Orchard.ContentManagement.Abstractions/IContentManagerSession.cs
+++ b/src/Orchard.ContentManagement.Abstractions/IContentManagerSession.cs
@@ -8,6 +8,7 @@ namespace Orchard.ContentManagement
         bool RecallVersionId(int id, out ContentItem item);
         bool RecallContentItemId(string id, int version, out ContentItem item);
         bool RecallPublishedItemId(string id, out ContentItem item);
+        bool RecallLatestItemId(string id, out ContentItem item);
 
         void Clear();
     }

--- a/src/Orchard.ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard.ContentManagement/DefaultContentManager.cs
@@ -112,6 +112,12 @@ namespace Orchard.ContentManagement
             }
             else if (options.IsLatest)
             {
+                // Check if the latest is already loaded
+                if (_contentManagerSession.RecallLatestItemId(contentItemId, out contentItem))
+                {
+                    return contentItem;
+                }
+
                 contentItem = await _session
                     .QueryAsync<ContentItem, ContentItemIndex>()
                     .Where(x => x.ContentItemId == contentItemId && x.Latest == true)
@@ -129,19 +135,23 @@ namespace Orchard.ContentManagement
             }
             else if (options.IsDraft || options.IsDraftRequired)
             {
-                // Loaded whatever is the latest as it will be cloned
-                contentItem = await _session
-                    .QueryAsync<ContentItem, ContentItemIndex>()
-                    .Where(x =>
-                        x.ContentItemId == contentItemId &&
-                        x.Latest == true)
-                    .FirstOrDefault();
+                // Check if the latest is already loaded
+                if (!_contentManagerSession.RecallLatestItemId(contentItemId, out contentItem))
+                {
+                    // Loaded whatever is the latest as it will be cloned
+                    contentItem = await _session
+                        .QueryAsync<ContentItem, ContentItemIndex>()
+                        .Where(x =>
+                            x.ContentItemId == contentItemId &&
+                            x.Latest == true)
+                        .FirstOrDefault();
+                }
             }
             else if (options.IsPublished)
             {
                 // If the published version is requested and is already loaded, we can
                 // return it right away
-                if(_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
+                if (_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
                 {
                     return contentItem;
                 }
@@ -154,33 +164,10 @@ namespace Orchard.ContentManagement
 
             if (contentItem == null)
             {
-                if (!options.IsDraftRequired)
-                {
-                    return null;
-                }
+                return null;
             }
 
-            // Return item if obtained earlier in session
-            // If IsPublished is required then the test has already been checked before
-            ContentItem recalled = null;
-            if (!_contentManagerSession.RecallVersionId(contentItem.Id, out recalled))
-            {
-                // store in session prior to loading to avoid some problems with simple circular dependencies
-                _contentManagerSession.Store(contentItem);
-
-                // create a context with a new instance to load
-                var context = new LoadContentContext(contentItem);
-
-                // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                Handlers.Invoke(handler => handler.Loading(context), _logger);
-                Handlers.Reverse().Invoke(handler => handler.Loaded(context), _logger);
-
-                contentItem = context.ContentItem;
-            }
-            else
-            {
-                contentItem = recalled;
-            }
+            contentItem = Load(contentItem);
 
             if (options.IsDraftRequired)
             {
@@ -198,6 +185,31 @@ namespace Orchard.ContentManagement
             }
 
             return contentItem;
+        }
+
+        private ContentItem Load(ContentItem contentItem)
+        {
+            // Return item if obtained earlier in session
+            // If IsPublished or IsLatest is required then the test has already been checked before
+            ContentItem recalled = null;
+            if (!_contentManagerSession.RecallVersionId(contentItem.Id, out recalled))
+            {
+                // store in session prior to loading to avoid some problems with simple circular dependencies
+                _contentManagerSession.Store(contentItem);
+
+                // create a context with a new instance to load
+                var context = new LoadContentContext(contentItem);
+
+                // invoke handlers to acquire state, or at least establish lazy loading callbacks
+                Handlers.Invoke(handler => handler.Loading(context), _logger);
+                Handlers.Reverse().Invoke(handler => handler.Loaded(context), _logger);
+
+                return context.ContentItem;
+            }
+            else
+            {
+                return recalled;
+            }
         }
 
         public async Task PublishAsync(ContentItem contentItem)
@@ -275,7 +287,7 @@ namespace Orchard.ContentManagement
             Handlers.Invoke(handler => handler.Unpublishing(context), _logger);
 
             publishedItem.Published = false;
-            
+
             _session.Save(publishedItem);
 
             Handlers.Reverse().Invoke(handler => handler.Unpublished(context), _logger);


### PR DESCRIPTION
It's a subset of the Versionable PR #531 which can be considered separately because it has nothing to do with the Versionable option.

So, if the Versionable PR is closed but this one is merged (if ok) we could still have these separate changes. And if we keep the Versionable PR open, i would be able to rebase it and make it simpler.

So here.

- In `DefaultContentManagerSession` when we recall a published item, **we check if it is still published**.

- Then, we also implement `RecallLatestItemId()` in the same way and the same added checking.

- In `DefaultContentManager` we use the new `RecallLatestItemId()` to see if the latest is already loaded.

- And finally a little refactoring by wrapping the code to load an item in a private `Load()` method.

Best.