### PR TITLE
Mysql and Sqlite support

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Modules.Abstractions/Services/IClock.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Abstractions/Services/IClock.cs
@@ -2,16 +2,16 @@
 
 namespace Orchard.Services
 {
-    /// <summary>
-    /// Provides the current Utc <see cref="DateTimeOffset"/>, and time related method for cache management.
-    /// This service should be used whenever the current date and time are needed, instead of <seealso cref="DateTimeOffset"/> directly.
-    /// It also makes implementations more testable, as time can be mocked.
-    /// </summary>
-    public interface IClock
+	/// <summary>
+	/// Provides the current Utc <see cref="DateTime"/>, and time related method for cache management.
+	/// This service should be used whenever the current date and time are needed, instead of <seealso cref="DateTime"/> directly.
+	/// It also makes implementations more testable, as time can be mocked.
+	/// </summary>
+	public interface IClock
     {
-        /// <summary>
-        /// Gets the current <see cref="DateTimeOffset"/> of the system, expressed in Utc
-        /// </summary>
-        DateTimeOffset UtcNow { get; }
+		/// <summary>
+		/// Gets the current <see cref="DateTime"/> of the system, expressed in Utc
+		/// </summary>
+		DateTime UtcNow { get; }
     }
 }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/DateEditorViewModel.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Contents/ViewModels/DateEditorViewModel.cs
@@ -4,6 +4,6 @@ namespace Orchard.Contents.ViewModels
 {
     public class DateEditorViewModel
     {
-        public DateTimeOffset? CreatedUtc { get; set; }
+        public DateTime? CreatedUtc { get; set; }
     }
 }

--- a/src/Orchard.Cms.Web/Modules/Orchard.Indexing/Migrations.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Indexing/Migrations.cs
@@ -10,7 +10,7 @@ namespace Orchard.Indexing
             SchemaBuilder.CreateTable(nameof(IndexingTask), table => table
                 .Column<int>(nameof(IndexingTask.Id), col => col.PrimaryKey().Identity())
                 .Column<string>(nameof(IndexingTask.ContentItemId), c => c.WithLength(26))
-                .Column<DateTimeOffset>(nameof(IndexingTask.CreatedUtc), col => col.NotNull())
+                .Column<DateTime>(nameof(IndexingTask.CreatedUtc), col => col.NotNull())
                 .Column<int>(nameof(IndexingTask.Type))
             );
 

--- a/src/Orchard.Cms.Web/Modules/Orchard.Modules/Recipes/Executors/FeatureStep.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Modules/Recipes/Executors/FeatureStep.cs
@@ -64,8 +64,6 @@ namespace Orchard.Modules.Recipes.Executors
 
                 await _shellFeatureManager.EnableFeaturesAsync(featuresToEnable, true);
             }
-
-            await Task.CompletedTask;
         }
 
         private class FeatureStepModel

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Startup.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Startup.cs
@@ -15,8 +15,9 @@ namespace Orchard.Setup
             services.AddScoped<ISetupService, SetupService>();
 
             services.TryAddDataProvider(name: "Sql Server", value: "SqlConnection", hasConnectionString: true );
-			services.TryAddDataProvider(name: "Sql Lite", value: "Sqlite", hasConnectionString: false);
+			services.TryAddDataProvider(name: "Sqlite", value: "Sqlite", hasConnectionString: false);
 			services.TryAddDataProvider(name: "MySql", value: "MySql", hasConnectionString: true);
+			services.TryAddDataProvider(name: "Postgres", value: "Postgres", hasConnectionString: true);
 		}
 
 		public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Startup.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Startup.cs
@@ -15,10 +15,11 @@ namespace Orchard.Setup
             services.AddScoped<ISetupService, SetupService>();
 
             services.TryAddDataProvider(name: "Sql Server", value: "SqlConnection", hasConnectionString: true );
-            services.TryAddDataProvider(name: "Sql Lite", value: "Sqlite", hasConnectionString: false );
-        }
+			services.TryAddDataProvider(name: "Sql Lite", value: "Sqlite", hasConnectionString: false);
+			services.TryAddDataProvider(name: "MySql", value: "MySql", hasConnectionString: true);
+		}
 
-        public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)
+		public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
             routes.MapAreaRoute(
                 name: "Setup",

--- a/src/Orchard.Cms.Web/Modules/Orchard.Tokens/StandardTokens.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Tokens/StandardTokens.cs
@@ -17,7 +17,7 @@ namespace Orchard.Tokens
                 var siteService = serviceProvider.GetRequiredService<ISiteService>();
                 var site = siteService.GetSiteSettingsAsync().Result;
                 var timeZone = TimeZoneInfo.FindSystemTimeZoneById(site.TimeZone);
-                var now = TimeZoneInfo.ConvertTime(clock.UtcNow.UtcDateTime, TimeZoneInfo.Utc, timeZone);
+                var now = TimeZoneInfo.ConvertTime(clock.UtcNow, TimeZoneInfo.Utc, timeZone);
 
                 var format = arguments[0].ToString();
                 output.Write(now.ToString(format));

--- a/src/Orchard.Cms.Web/project.json
+++ b/src/Orchard.Cms.Web/project.json
@@ -16,7 +16,8 @@
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
     "System.Dynamic.Runtime": "4.3.0",
     "Microsoft.Extensions.Localization.Abstractions": "1.1.0",
-    "Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Design": "1.1.0-*"
+			"Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Design": "1.1.0-*",
+			"sqlite": "3.13.0"
   },
   "runtimeOptions": {
     "configProperties": {

--- a/src/Orchard.Cms.Web/project.json
+++ b/src/Orchard.Cms.Web/project.json
@@ -1,24 +1,24 @@
 {
   "webroot": "wwwroot",
   "version": "2.0.0-*",
-  "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
-    "System.Linq": "4.3.0",
-    "System.Collections.Specialized": "4.3.0",
-    "Microsoft.AspNetCore.Mvc.Modules.Hosting": "1.0.0-*",
-    "Orchard.Environment.Shell.Data": "2.0.0-*",
-    "Orchard.DisplayManagement": "2.0.0-*",
-    "Orchard.Hosting.Console": "2.0.0-*",
-    "Orchard.Recipes.Abstractions": "2.0.0-*",
-    "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "Microsoft.AspNetCore.Diagnostics": "1.1.0",
-    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
-    "System.Dynamic.Runtime": "4.3.0",
-    "Microsoft.Extensions.Localization.Abstractions": "1.1.0",
-			"Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Design": "1.1.0-*",
-			"sqlite": "3.13.0"
-  },
+	"dependencies": {
+		"Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+		"Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
+		"System.Linq": "4.3.0",
+		"System.Collections.Specialized": "4.3.0",
+		"Microsoft.AspNetCore.Mvc.Modules.Hosting": "1.0.0-*",
+		"Orchard.Environment.Shell.Data": "2.0.0-*",
+		"Orchard.DisplayManagement": "2.0.0-*",
+		"Orchard.Hosting.Console": "2.0.0-*",
+		"Orchard.Recipes.Abstractions": "2.0.0-*",
+		"Microsoft.Extensions.Logging.Console": "1.1.0",
+		"Microsoft.AspNetCore.Diagnostics": "1.1.0",
+		"Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
+		"System.Dynamic.Runtime": "4.3.0",
+		"Microsoft.Extensions.Localization.Abstractions": "1.1.0",
+		"Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Design": "1.1.0-*",
+		"Microsoft.Data.Sqlite": "1.1.0"
+	},
   "runtimeOptions": {
     "configProperties": {
       "System.GC.Server": true

--- a/src/Orchard.ContentManagement.Abstractions/ContentItem.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentItem.cs
@@ -47,17 +47,17 @@ namespace Orchard.ContentManagement
         /// <summary>
         /// When the content item version has been updated.
         /// </summary>
-        public DateTimeOffset? ModifiedUtc { get; set; }
+        public DateTime? ModifiedUtc { get; set; }
 
         /// <summary>
         /// When the content item has been published.
         /// </summary>
-        public DateTimeOffset? PublishedUtc { get; set; }
+        public DateTime? PublishedUtc { get; set; }
 
         /// <summary>
         /// When the content item has been created or first published.
         /// </summary>
-        public DateTimeOffset? CreatedUtc { get; set; }
+        public DateTime? CreatedUtc { get; set; }
 
         /// <summary>
         /// The name of the user who first created this content item version

--- a/src/Orchard.ContentManagement.Abstractions/ContentItemConverter.cs
+++ b/src/Orchard.ContentManagement.Abstractions/ContentItemConverter.cs
@@ -72,13 +72,13 @@ namespace Orchard.ContentManagement
                         contentItem.Published = reader.ReadAsBoolean() ?? false;
                         break;
                     case nameof(ContentItem.PublishedUtc):
-                        contentItem.PublishedUtc = reader.ReadAsDateTimeOffset();
+                        contentItem.PublishedUtc = reader.ReadAsDateTime();
                         break;
                     case nameof(ContentItem.ModifiedUtc):
-                        contentItem.ModifiedUtc = reader.ReadAsDateTimeOffset();
+                        contentItem.ModifiedUtc = reader.ReadAsDateTime();
                         break;
                     case nameof(ContentItem.CreatedUtc):
-                        contentItem.CreatedUtc = reader.ReadAsDateTimeOffset();
+                        contentItem.CreatedUtc = reader.ReadAsDateTime();
                         break;
                     case nameof(ContentItem.Author):
                         contentItem.Author = reader.ReadAsString();

--- a/src/Orchard.ContentManagement/Records/ContentItemIndex.cs
+++ b/src/Orchard.ContentManagement/Records/ContentItemIndex.cs
@@ -11,9 +11,9 @@ namespace Orchard.ContentManagement.Records
         public bool Published { get; set; }
         public bool Latest { get; set; }
         public string ContentType { get; set; }
-        public DateTimeOffset? ModifiedUtc { get; set; }
-        public DateTimeOffset? PublishedUtc { get; set; }
-        public DateTimeOffset? CreatedUtc { get; set; }
+        public DateTime? ModifiedUtc { get; set; }
+        public DateTime? PublishedUtc { get; set; }
+        public DateTime? CreatedUtc { get; set; }
         public string Owner { get; set; }
         public string Author { get; set; }
     }

--- a/src/Orchard.ContentManagement/Records/Migrations.cs
+++ b/src/Orchard.ContentManagement/Records/Migrations.cs
@@ -9,9 +9,9 @@ namespace Orchard.ContentManagement.Records
         {
             SchemaBuilder.CreateMapIndexTable(nameof(ContentItemIndex), table => table
                 .Column<string>("ContentItemId", c => c.WithLength(26))
-                .Column<int>("Latest")
+                .Column<bool>("Latest")
                 .Column<int>("Number")
-                .Column<int>("Published")
+                .Column<bool>("Published")
                 .Column<string>("ContentType", column => column.WithLength(255))
                 .Column<DateTime>("ModifiedUtc", column => column.Nullable())
                 .Column<DateTime>("PublishedUtc", column => column.Nullable())

--- a/src/Orchard.Data.Abstractions/project.json
+++ b/src/Orchard.Data.Abstractions/project.json
@@ -2,7 +2,7 @@
   "version": "2.0.0-*",
   "dependencies": {
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
-    "YesSql.Core": "2.0.0-*"
+    "YesSql.Core": "2.0.0-beta-0011"
   },
   "buildOptions": {
     "debugType": "portable"

--- a/src/Orchard.Data/Migration/DataMigrationManager.cs
+++ b/src/Orchard.Data/Migration/DataMigrationManager.cs
@@ -232,7 +232,7 @@ namespace Orchard.Data.Migration
                         _session.Save(_dataMigrationRecord);
                     }
                 });
-            }
+			}
         }
 
         private async Task<Records.DataMigration> GetDataMigrationRecordAsync(IDataMigration tempMigration)

--- a/src/Orchard.Data/ServiceCollectionExtensions.cs
+++ b/src/Orchard.Data/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using MySql.Data.MySqlClient;
+using Npgsql;
 using Orchard.Data.Migration;
 using Orchard.Environment.Shell;
 using YesSql.Core.Indexes;
@@ -24,8 +25,9 @@ namespace Orchard.Data
 
             // Adding supported databases
             services.TryAddDataProvider(name: "Sql Server", value: "SqlConnection", hasConnectionString: true);
-            services.TryAddDataProvider(name: "Sql Lite", value: "Sqlite", hasConnectionString: false);
+            services.TryAddDataProvider(name: "Sqlite", value: "Sqlite", hasConnectionString: false);
 			services.TryAddDataProvider(name: "MySql", value: "MySql", hasConnectionString: true);
+			services.TryAddDataProvider(name: "Postgres", value: "Postgres", hasConnectionString: true);
 
 			// Configuring data access
 
@@ -57,6 +59,10 @@ namespace Orchard.Data
 						break;
 					case "MySql":
 						connectionFactory = new DbConnectionFactory<MySqlConnection>(shellSettings.ConnectionString);
+						isolationLevel = IsolationLevel.ReadUncommitted;
+						break;
+					case "Postgres":
+						connectionFactory = new DbConnectionFactory<NpgsqlConnection>(shellSettings.ConnectionString);
 						isolationLevel = IsolationLevel.ReadUncommitted;
 						break;
 					default:

--- a/src/Orchard.Data/ServiceCollectionExtensions.cs
+++ b/src/Orchard.Data/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
+using MySql.Data.MySqlClient;
 using Orchard.Data.Migration;
 using Orchard.Environment.Shell;
 using YesSql.Core.Indexes;
@@ -24,10 +25,11 @@ namespace Orchard.Data
             // Adding supported databases
             services.TryAddDataProvider(name: "Sql Server", value: "SqlConnection", hasConnectionString: true);
             services.TryAddDataProvider(name: "Sql Lite", value: "Sqlite", hasConnectionString: false);
+			services.TryAddDataProvider(name: "MySql", value: "MySql", hasConnectionString: true);
 
-            // Configuring data access
+			// Configuring data access
 
-            services.AddSingleton<IStore>(sp =>
+			services.AddSingleton<IStore>(sp =>
             {
                 var shellSettings = sp.GetService<ShellSettings>();
                 var hostingEnvironment = sp.GetService<IHostingEnvironment>();
@@ -52,8 +54,12 @@ namespace Orchard.Data
                         Directory.CreateDirectory(databaseFolder);
                         connectionFactory = new DbConnectionFactory<SqliteConnection>($"Data Source={databaseFile};Cache=Shared");
                         isolationLevel = IsolationLevel.ReadUncommitted;
-                        break;
-                    default:
+						break;
+					case "MySql":
+						connectionFactory = new DbConnectionFactory<MySqlConnection>(shellSettings.ConnectionString);
+						isolationLevel = IsolationLevel.ReadUncommitted;
+						break;
+					default:
                         throw new ArgumentException("Unknown database provider: " + shellSettings.DatabaseProvider);
                 }
 

--- a/src/Orchard.Data/project.json
+++ b/src/Orchard.Data/project.json
@@ -10,7 +10,7 @@
 		"Orchard.Environment.Shell.Abstractions": "2.0.0-*",
 		"YesSql.Storage.Sql": "1.0.0-beta-0004",
 		"Microsoft.Data.Sqlite": "1.1.0",
-		"MySqlConnector": "0.11.6",
+		"MySqlConnector": "0.12",
 		"Npgsql": "3.2.0"
 	},
   "buildOptions": {

--- a/src/Orchard.Data/project.json
+++ b/src/Orchard.Data/project.json
@@ -8,7 +8,6 @@
 		"Orchard.DependencyInjection": "2.0.0-*",
 		"Orchard.Environment.Extensions.Abstractions": "2.0.0-*",
 		"Orchard.Environment.Shell.Abstractions": "2.0.0-*",
-		"YesSql.Core": "2.0.0-beta-0010",
 		"YesSql.Storage.Sql": "1.0.0-beta-0004",
 		"Microsoft.Data.Sqlite": "1.1.0",
 		"MySqlConnector": "0.11.6",

--- a/src/Orchard.Data/project.json
+++ b/src/Orchard.Data/project.json
@@ -1,16 +1,17 @@
 {
   "version": "2.0.0-*",
-  "dependencies": {
-    "Microsoft.Data.Sqlite": "1.1.0",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
-    "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
-    "Newtonsoft.Json": "9.0.1",
-    "Orchard.Data.Abstractions": "2.0.0-*",
-    "Orchard.DependencyInjection": "2.0.0-*",
-    "Orchard.Environment.Extensions.Abstractions": "2.0.0-*",
-    "Orchard.Environment.Shell.Abstractions": "2.0.0-*",
-    "YesSql.Storage.Sql": "1.0.0-*"
-  },
+	"dependencies": {
+		"Microsoft.Data.Sqlite": "1.1.0",
+		"MySqlConnector": "0.11.6",
+		"Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
+		"Microsoft.Extensions.Logging.Abstractions": "1.1.0",
+		"Newtonsoft.Json": "9.0.1",
+		"Orchard.Data.Abstractions": "2.0.0-*",
+		"Orchard.DependencyInjection": "2.0.0-*",
+		"Orchard.Environment.Extensions.Abstractions": "2.0.0-*",
+		"Orchard.Environment.Shell.Abstractions": "2.0.0-*",
+		"YesSql.Storage.Sql": "1.0.0-*"
+	},
   "buildOptions": {
     "debugType": "portable"
   },

--- a/src/Orchard.Data/project.json
+++ b/src/Orchard.Data/project.json
@@ -1,8 +1,6 @@
 {
   "version": "2.0.0-*",
 	"dependencies": {
-		"Microsoft.Data.Sqlite": "1.1.0",
-		"MySqlConnector": "0.11.6",
 		"Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0",
 		"Microsoft.Extensions.Logging.Abstractions": "1.1.0",
 		"Newtonsoft.Json": "9.0.1",
@@ -10,7 +8,11 @@
 		"Orchard.DependencyInjection": "2.0.0-*",
 		"Orchard.Environment.Extensions.Abstractions": "2.0.0-*",
 		"Orchard.Environment.Shell.Abstractions": "2.0.0-*",
-		"YesSql.Storage.Sql": "1.0.0-*"
+		"YesSql.Core": "2.0.0-beta-0010",
+		"YesSql.Storage.Sql": "1.0.0-beta-0004",
+		"Microsoft.Data.Sqlite": "1.1.0",
+		"MySqlConnector": "0.11.6",
+		"Npgsql": "3.2.0"
 	},
   "buildOptions": {
     "debugType": "portable"

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
@@ -191,9 +191,9 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeAttributeStrategy
             }
 
             // Specific implementation for DateTimes
-            if (result.GetType() == typeof(string) && (parameter.ParameterType == typeof(DateTimeOffset) || parameter.ParameterType == typeof(DateTimeOffset?)))
+            if (result.GetType() == typeof(string) && (parameter.ParameterType == typeof(DateTime) || parameter.ParameterType == typeof(DateTime?)))
             {
-                return DateTimeOffset.Parse((string)result);
+                return DateTime.Parse((string)result);
             }
 
             return Convert.ChangeType(result, parameter.ParameterType);

--- a/src/Orchard.DisplayManagement/README.md
+++ b/src/Orchard.DisplayManagement/README.md
@@ -69,7 +69,7 @@ Renders a Date and Time value using the timezone of the request.
 
 | Parameter | Type | Description |
 | --------- | ---- |------------ |
-| `Utc` | `DateTimeOffset?` | The date and time to render. If not specified, the current time will be used. |
+| `Utc` | `DateTime?` | The date and time to render. If not specified, the current time will be used. |
 | `Format` | `string` | The .NET format string. If not specified the long format `dddd, MMMM d, yyyy h:mm:ss tt` will be used. The accepted format can be found at https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx |
 
 Tag helper example:
@@ -84,8 +84,8 @@ Renders a relative textual representation of a Date and Time interval.
 
 | Parameter | Type | Description |
 | --------- | ---- |------------ |
-| `Utc` | `DateTimeOffset?` | The initial date and time. If not specified, the current time will be used. |
-| `Origin` | `DateTimeOffset?` | The current date and time. If not specified, the current time will be used. |
+| `Utc` | `DateTime?` | The initial date and time. If not specified, the current time will be used. |
+| `Origin` | `DateTime?` | The current date and time. If not specified, the current time will be used. |
 
 Tag helper example:
 

--- a/src/Orchard.DisplayManagement/Shapes/DateTimeShapes.cs
+++ b/src/Orchard.DisplayManagement/Shapes/DateTimeShapes.cs
@@ -37,7 +37,7 @@ namespace Orchard.DisplayManagement.Shapes
         IPluralStringLocalizer T { get; }
 
         [Shape]
-        public IHtmlContent TimeSpan(IHtmlHelper Html, DateTimeOffset? Utc, DateTimeOffset? Origin)
+        public IHtmlContent TimeSpan(IHtmlHelper Html, DateTime? Utc, DateTime? Origin)
         {
             Utc = Utc ?? _clock.UtcNow;
             Origin = Origin ?? _clock.UtcNow;
@@ -85,7 +85,7 @@ namespace Orchard.DisplayManagement.Shapes
         }
 
         [Shape]
-        public async Task<IHtmlContent> DateTime(IHtmlHelper Html, DateTimeOffset? Utc, string Format)
+        public async Task<IHtmlContent> DateTime(IHtmlHelper Html, DateTime? Utc, string Format)
         {
             if (Utc == null)
             {
@@ -93,7 +93,7 @@ namespace Orchard.DisplayManagement.Shapes
             }
 
             var timeZone = TimeZoneInfo.FindSystemTimeZoneById((await _siteService.GetSiteSettingsAsync()).TimeZone);
-            var local = TimeZoneInfo.ConvertTime(Utc.Value.UtcDateTime, TimeZoneInfo.Utc, timeZone);
+            var local = TimeZoneInfo.ConvertTime(Utc.Value.ToUniversalTime(), TimeZoneInfo.Utc, timeZone);
 
             if (Format == null)
             {

--- a/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
+++ b/src/Orchard.Environment.Shell/ShellFeaturesManager.cs
@@ -24,7 +24,8 @@ namespace Orchard.Environment.Shell
             _shellDescriptorFeaturesManager = shellDescriptorFeaturesManager;
         }
 
-        private Task<ShellDescriptor> GetCurrentShell() {
+        private Task<ShellDescriptor> GetCurrentShell()
+		{
             return _shellDescriptorManager.GetShellDescriptorAsync();
         }
 

--- a/src/Orchard.Hosting/Services/Clock.cs
+++ b/src/Orchard.Hosting/Services/Clock.cs
@@ -5,9 +5,9 @@ namespace Orchard.Hosting.Services
 {
     public class Clock : IClock
     {
-        public DateTimeOffset UtcNow
+        public DateTime UtcNow
         {
-            get { return DateTimeOffset.UtcNow; }
+            get { return DateTime.UtcNow; }
         }
     }
 }


### PR DESCRIPTION
Just for visibility.

I had to remove the usage of `DateTimeOffset` for now as it's not supported by MySqlConnector provider (or even the Orchard provider). I have submitted a PR to them. But even though it would not work, it's kind of useless to use `DateTimeOffset` as we are always manipulating UTC in code and in the database, so I am not really sad about it. Whoever tells me we need to use `DateTimeOffset` because it's better doesn't understand date and times and databases.