### PR TITLE
Types and references on mvcless.

### DIFF
--- a/src/Microsoft.AspNetCore.Modules.Abstractions/DefaultModularAssemblyDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/DefaultModularAssemblyDiscoveryProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Modules
         // Returns a list of assemblies that references the assemblies in referenceAssemblies
         public static IEnumerable<Assembly> GetCandidateAssemblies(IEnumerable<Assembly> assemblies, ISet<string> referenceAssemblies)
         {
-            if (!referenceAssemblies.Any())
+            if (!assemblies.Any() || !referenceAssemblies.Any())
             {
                 return Enumerable.Empty<Assembly>();
             }

--- a/src/Microsoft.AspNetCore.Modules.Abstractions/DefaultModularAssemblyDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/DefaultModularAssemblyDiscoveryProvider.cs
@@ -3,33 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Microsoft.AspNetCore.Mvc.Modules
+namespace Microsoft.AspNetCore.Modules
 {
-    // Discovers assemblies that are part of the modular MVC application.
-    public static class DefaultModularMvcAssemblyDiscoveryProvider
+    public static class DefaultModularAssemblyDiscoveryProvider
     {
-        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "Microsoft.AspNetCore.Mvc",
-            "Microsoft.AspNetCore.Mvc.Abstractions",
-            "Microsoft.AspNetCore.Mvc.ApiExplorer",
-            "Microsoft.AspNetCore.Mvc.Core",
-            "Microsoft.AspNetCore.Mvc.Cors",
-            "Microsoft.AspNetCore.Mvc.DataAnnotations",
-            "Microsoft.AspNetCore.Mvc.Formatters.Json",
-            "Microsoft.AspNetCore.Mvc.Formatters.Xml",
-            "Microsoft.AspNetCore.Mvc.Localization",
-            "Microsoft.AspNetCore.Mvc.Razor",
-            "Microsoft.AspNetCore.Mvc.Razor.Host",
-            "Microsoft.AspNetCore.Mvc.RazorPages",
-            "Microsoft.AspNetCore.Mvc.TagHelpers",
-            "Microsoft.AspNetCore.Mvc.ViewFeatures"
-        };
-
-        // Returns a list of assemblies that references the assemblies in referenceAssemblies.
-        // By default it returns all assemblies that reference any of the primary MVC assemblies
-        // while ignoring MVC assemblies.
-        // Internal for unit testing
+        // Returns a list of assemblies that references the assemblies in referenceAssemblies
         public static IEnumerable<Assembly> GetCandidateAssemblies(IEnumerable<Assembly> assemblies, ISet<string> referenceAssemblies)
         {
             if (!referenceAssemblies.Any())
@@ -64,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.Modules
                 var classification = DependencyClassification.Unknown;
                 if (referenceAssemblies.Contains(assembly.GetName().Name))
                 {
-                    classification = DependencyClassification.MvcReference;
+                    classification = DependencyClassification.Reference;
                 }
 
                 return new Dependency(assembly, classification);
@@ -90,7 +68,7 @@ namespace Microsoft.AspNetCore.Mvc.Modules
                     {
                         var dependencyClassification = ComputeClassification(candidateDependency.Name);
                         if (dependencyClassification == DependencyClassification.Candidate ||
-                            dependencyClassification == DependencyClassification.MvcReference)
+                            dependencyClassification == DependencyClassification.Reference)
                         {
                             classification = DependencyClassification.Candidate;
                             break;
@@ -131,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.Modules
                 Unknown = 0,
                 Candidate = 1,
                 NotCandidate = 2,
-                MvcReference = 3
+                Reference = 3
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
@@ -6,6 +6,6 @@ namespace Microsoft.AspNetCore.Modules
     public interface IModularAssemblyProvider
     {
         IEnumerable<Assembly> GetAssemblies();
-        IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies);
+        IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies, ISet<string> referenceAssemblies);
     }
 }

--- a/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
@@ -5,7 +5,6 @@ namespace Microsoft.AspNetCore.Modules
 {
     public interface IModularAssemblyProvider
     {
-        IEnumerable<Assembly> GetAssemblies();
         IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies, ISet<string> referenceAssemblies);
     }
 }

--- a/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
@@ -6,5 +6,6 @@ namespace Microsoft.AspNetCore.Modules
     public interface IModularAssemblyProvider
     {
         IEnumerable<Assembly> GetAssemblies();
+        IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies);
     }
 }

--- a/src/Microsoft.AspNetCore.Modules/ModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules/ModularAssemblyProvider.cs
@@ -21,11 +21,11 @@ namespace Microsoft.AspNetCore.Modules
         private IList<Assembly> CachedRuntimeAssemblies;
 
         // Returns a list of assemblies and their dependencies contained in runtimeAssemblies
-        public IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies)
+        public IEnumerable<Assembly> GetAssemblies(IEnumerable<Assembly> runtimeAssemblies, ISet<string> referenceAssemblies)
         {
             if (CachedRuntimeAssemblies == null)
             {
-                if (!runtimeAssemblies.Any())
+                if (!runtimeAssemblies.Any() || !referenceAssemblies.Any())
                 {
                     return Enumerable.Empty<Assembly>();
                 }
@@ -47,8 +47,11 @@ namespace Microsoft.AspNetCore.Modules
                     }
                 }
 
-                CachedRuntimeAssemblies = runtimeAssemblies
-                    .Where(a => references.Contains(a.GetName().Name))
+                CachedRuntimeAssemblies = DefaultModularAssemblyDiscoveryProvider
+                    .GetCandidateAssemblies(
+                        runtimeAssemblies
+                        .Where(a => references.Contains(a.GetName().Name)),
+                        referenceAssemblies)
                     .ToList();
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Modules.Abstractions/DefaultMvcAssemblyDiscoveryProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules.Abstractions/DefaultMvcAssemblyDiscoveryProvider.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Mvc.Modules
+{
+    // Discovers assemblies that are part of the modular MVC application.
+    public static class DefaultModularMvcAssemblyDiscoveryProvider
+    {
+        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Microsoft.AspNetCore.Mvc",
+            "Microsoft.AspNetCore.Mvc.Abstractions",
+            "Microsoft.AspNetCore.Mvc.ApiExplorer",
+            "Microsoft.AspNetCore.Mvc.Core",
+            "Microsoft.AspNetCore.Mvc.Cors",
+            "Microsoft.AspNetCore.Mvc.DataAnnotations",
+            "Microsoft.AspNetCore.Mvc.Formatters.Json",
+            "Microsoft.AspNetCore.Mvc.Formatters.Xml",
+            "Microsoft.AspNetCore.Mvc.Localization",
+            "Microsoft.AspNetCore.Mvc.Razor",
+            "Microsoft.AspNetCore.Mvc.Razor.Host",
+            "Microsoft.AspNetCore.Mvc.RazorPages",
+            "Microsoft.AspNetCore.Mvc.TagHelpers",
+            "Microsoft.AspNetCore.Mvc.ViewFeatures"
+        };
+
+        // Returns a list of assemblies that references the assemblies in referenceAssemblies.
+        // By default it returns all assemblies that reference any of the primary MVC assemblies
+        // while ignoring MVC assemblies.
+        // Internal for unit testing
+        public static IEnumerable<Assembly> GetCandidateAssemblies(IEnumerable<Assembly> assemblies, ISet<string> referenceAssemblies)
+        {
+            if (!referenceAssemblies.Any())
+            {
+                return Enumerable.Empty<Assembly>();
+            }
+
+            var candidatesResolver = new CandidateResolver(assemblies, referenceAssemblies);
+            return candidatesResolver.GetCandidates();
+        }
+
+        private class CandidateResolver
+        {
+            private readonly IDictionary<string, Dependency> _dependencies = new Dictionary<string, Dependency>(StringComparer.OrdinalIgnoreCase);
+
+            public CandidateResolver(IEnumerable<Assembly> assemblies, ISet<string> referenceAssemblies)
+            {
+                var dependenciesWithNoDuplicates = new Dictionary<string, Dependency>(StringComparer.OrdinalIgnoreCase);
+                foreach (var assembly in assemblies)
+                {
+                    if (!dependenciesWithNoDuplicates.ContainsKey(assembly.GetName().Name))
+                    {
+                        dependenciesWithNoDuplicates.Add(assembly.GetName().Name, CreateDependency(assembly, referenceAssemblies));
+                    }
+                }
+
+                _dependencies = dependenciesWithNoDuplicates;
+            }
+
+            private Dependency CreateDependency(Assembly assembly, ISet<string> referenceAssemblies)
+            {
+                var classification = DependencyClassification.Unknown;
+                if (referenceAssemblies.Contains(assembly.GetName().Name))
+                {
+                    classification = DependencyClassification.MvcReference;
+                }
+
+                return new Dependency(assembly, classification);
+            }
+
+            private DependencyClassification ComputeClassification(string dependency)
+            {
+                if (!_dependencies.ContainsKey(dependency))
+                {
+                    return DependencyClassification.Unknown;
+                }
+
+                var candidateEntry = _dependencies[dependency];
+                if (candidateEntry.Classification != DependencyClassification.Unknown)
+                {
+                    return candidateEntry.Classification;
+                }
+                else
+                {
+                    var classification = DependencyClassification.NotCandidate;
+
+                    foreach (var candidateDependency in candidateEntry.Assembly.GetReferencedAssemblies())
+                    {
+                        var dependencyClassification = ComputeClassification(candidateDependency.Name);
+                        if (dependencyClassification == DependencyClassification.Candidate ||
+                            dependencyClassification == DependencyClassification.MvcReference)
+                        {
+                            classification = DependencyClassification.Candidate;
+                            break;
+                        }
+                    }
+
+                    candidateEntry.Classification = classification;
+
+                    return classification;
+                }
+            }
+
+            public IEnumerable<Assembly> GetCandidates()
+            {
+                foreach (var dependency in _dependencies)
+                {
+                    if (ComputeClassification(dependency.Key) == DependencyClassification.Candidate)
+                    {
+                        yield return dependency.Value.Assembly;
+                    }
+                }
+            }
+
+            private class Dependency
+            {
+                public Dependency(Assembly assembly, DependencyClassification classification)
+                {
+                    Assembly = assembly;
+                    Classification = classification;
+                }
+
+                public Assembly Assembly { get; }
+                public DependencyClassification Classification { get; set; }
+            }
+
+            private enum DependencyClassification
+            {
+                Unknown = 0,
+                Candidate = 1,
+                NotCandidate = 2,
+                MvcReference = 3
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Modules/DesignTimeMvcBuilderConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/DesignTimeMvcBuilderConfiguration.cs
@@ -22,7 +22,7 @@ namespace Orchard.Cms.Web
             //{
             //    var extensionLibraryService = serviceProvider.GetRequiredService<IExtensionLibraryService>();
             //    apm.FeatureProviders.Add(
-            //        new ExtensionMetadataReferenceFeatureProvider(extensionLibraryService.MetadataPaths.ToArray()));
+            //        new ExtensionMetadataReferenceFeatureProvider(extensionLibraryService.ReferencePaths.ToArray()));
             //});
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.PortableExecutable;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
@@ -16,7 +14,6 @@ using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Orchard.Environment.Extensions;
 
 namespace Microsoft.AspNetCore.Mvc.Modules
 {
@@ -86,15 +83,6 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         {
             return builder.AddRazorViewEngine(options =>
             {
-                var extensionLibraryService =
-                    services.GetService<IExtensionLibraryService>();
-
-                foreach (var metadataPath in extensionLibraryService.MetadataPaths)
-                {
-                    var metadata = CreateMetadataReference(metadataPath);
-                    options.AdditionalCompilationReferences.Add(metadata);
-                }
-
                 options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
             });
         }
@@ -110,17 +98,6 @@ namespace Microsoft.AspNetCore.Mvc.Modules
                 ServiceDescriptor.Transient<IApplicationModelProvider, ModularApplicationModelProvider>());
             services.Replace(
                 ServiceDescriptor.Transient<ITagHelperTypeResolver, FeatureTagHelperTypeResolver>());
-        }
-
-        private static MetadataReference CreateMetadataReference(string path)
-        {
-            using (var stream = File.OpenRead(path))
-            {
-                var moduleMetadata = ModuleMetadata.CreateFromStream(stream, PEStreamOptions.PrefetchMetadata);
-                var assemblyMetadata = AssemblyMetadata.Create(moduleMetadata);
-
-                return assemblyMetadata.GetReference(filePath: path);
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Modules/ModularApplicationPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/ModularApplicationPart.cs
@@ -75,14 +75,9 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         {
             get
             {
-                var assemblies = ModularAssemblyProvider
-                    .GetAssemblies(ExtensionLibraryService.RuntimeLibraries);
-
-                var types = DefaultModularAssemblyDiscoveryProvider
-                    .GetCandidateAssemblies(assemblies, ReferenceAssemblies)
+                return ModularAssemblyProvider
+                    .GetAssemblies(ExtensionLibraryService.RuntimeLibraries, ReferenceAssemblies)
                     .SelectMany(x => x.DefinedTypes);
-
-                return types;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Modules/ModularApplicationPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/ModularApplicationPart.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using Orchard.Environment.Extensions;
-using Orchard.Environment.Shell.Builders.Models;
 
 namespace Microsoft.AspNetCore.Mvc.Modules
 {
@@ -57,11 +56,8 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         /// </summary>
         public IHttpContextAccessor HttpContextAccessor { get; }
 
-        private IModularAssemblyProvider AssemblyProvider =>
-            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IModularAssemblyProvider>();
-
-        private ShellBlueprint ShellBlueprint =>
-            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<ShellBlueprint>();
+        private IExtensionLibraryService ExtensionLibraryService =>
+            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IExtensionLibraryService>();
 
         public override string Name
         {
@@ -76,11 +72,8 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         {
             get
             {
-                var serviceProvider = HttpContextAccessor.HttpContext.RequestServices;
-                var extensionLibraryServices = serviceProvider.GetRequiredService<IExtensionLibraryService>();
-
-                return DefaultModularMvcAssemblyDiscoveryProvider
-                    .GetCandidateAssemblies(extensionLibraryServices.LoadedAssemblies, ReferenceAssemblies)
+                return DefaultModularAssemblyDiscoveryProvider
+                    .GetCandidateAssemblies(ExtensionLibraryService.LoadedAssemblies, ReferenceAssemblies)
                     .SelectMany(x => x.DefinedTypes);
             }
         }
@@ -88,12 +81,9 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         /// <inheritdoc />
         public IEnumerable<string> GetReferencePaths()
         {
-            var serviceProvider = HttpContextAccessor.HttpContext.RequestServices;
-            var extensionLibraryServices = serviceProvider.GetRequiredService<IExtensionLibraryService>();
-
             return DependencyContext.Default.CompileLibraries
                 .SelectMany(library => library.ResolveReferencePaths())
-                .Union(extensionLibraryServices.MetadataPaths);
+                .Union(ExtensionLibraryService.MetadataPaths);
         }
     }
 } 

--- a/src/Orchard.Cms.Web/project.json
+++ b/src/Orchard.Cms.Web/project.json
@@ -19,6 +19,7 @@
   },
   "buildOptions": {
     "emitEntryPoint": true,
+    "preserveCompilationContext": true,
     "debugType": "portable",
     "compile": {
       "exclude": [

--- a/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
@@ -29,14 +29,14 @@ namespace Orchard.Environment.Extensions
         Assembly LoadDynamicExtension(IExtensionInfo extensionInfo);
 
         /// <summary>
-        /// Lists references of all the available extensions.
+        /// Lists compilation references of all extensions
         /// </summary>
-        IEnumerable<string> MetadataPaths { get; }
+        IEnumerable<string> ReferencePaths { get; }
 
         /// <summary>
-        /// Lists all assemblies dynamically loaded.
+        /// Lists all runtime libraries dynamically loaded.
         /// Returns <see cref="Assembly"/> instances.
         /// </summary>
-        IEnumerable<Assembly> LoadedAssemblies { get; }
+        IEnumerable<Assembly> RuntimeLibraries { get; }
     }
 }

--- a/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
@@ -30,7 +30,6 @@ namespace Orchard.Environment.Extensions
 
         /// <summary>
         /// Lists references of all the available extensions.
-        /// Returns <see cref="MetadataReference"/> instances.
         /// </summary>
         IEnumerable<string> MetadataPaths { get; }
 

--- a/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions.Abstractions/IExtensionLibraryService.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace Orchard.Environment.Extensions
 {
@@ -33,5 +33,11 @@ namespace Orchard.Environment.Extensions
         /// Returns <see cref="MetadataReference"/> instances.
         /// </summary>
         IEnumerable<string> MetadataPaths { get; }
+
+        /// <summary>
+        /// Lists all assemblies dynamically loaded.
+        /// Returns <see cref="Assembly"/> instances.
+        /// </summary>
+        IEnumerable<Assembly> LoadedAssemblies { get; }
     }
 }

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -50,7 +50,8 @@ namespace Orchard.Environment.Extensions
             _logger = logger;
         }
 
-        public IEnumerable<string> MetadataPaths {
+        public IEnumerable<string> ReferencePaths
+        {
             get {
                 var assemblyNames = new HashSet<string>(ApplicationAssemblyNames, StringComparer.OrdinalIgnoreCase);
                 var assemblyLocations = new List<string>();
@@ -75,7 +76,7 @@ namespace Orchard.Environment.Extensions
             }
         }
 
-        public IEnumerable<Assembly> LoadedAssemblies
+        public IEnumerable<Assembly> RuntimeLibraries
         {
             get
             {

--- a/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionLibraryService.cs
@@ -74,7 +74,15 @@ namespace Orchard.Environment.Extensions
                 return assemblyLocations;
             }
         }
-        
+
+        public IEnumerable<Assembly> LoadedAssemblies
+        {
+            get
+            {
+                return _loadedAssemblies.Select(x => x.Value.Value);
+            }
+        }
+
         private static HashSet<string> GetApplicationAssemblyNames()
         {
             return new HashSet<string>(DependencyContext.Default.RuntimeLibraries

--- a/src/Orchard.Environment.Extensions/ExtensionManager.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionManager.cs
@@ -148,14 +148,23 @@ namespace Orchard.Environment.Extensions
         {
             EnsureInitialized();
 
-            return Task.FromResult<IEnumerable<FeatureEntry>>(_features.Values);
+            var orderedFeaturesIds = GetFeatures().Select(f => f.Id).ToList();
+
+            var loadedFeatures = _features.Values
+                .OrderBy(f => orderedFeaturesIds.IndexOf(f.FeatureInfo.Id));
+
+            return Task.FromResult<IEnumerable<FeatureEntry>>(loadedFeatures);
         }
 
         public Task<IEnumerable<FeatureEntry>> LoadFeaturesAsync(string[] featureIdsToLoad)
         {
             EnsureInitialized();
 
-            var loadedFeatures = _features.Values.Where(f => featureIdsToLoad.Contains(f.FeatureInfo.Id));
+            var orderedFeaturesIds = GetFeatures().Select(f => f.Id).ToList();
+
+            var loadedFeatures = _features.Values
+                .Where(f => featureIdsToLoad.Contains(f.FeatureInfo.Id))
+                .OrderBy(f => orderedFeaturesIds.IndexOf(f.FeatureInfo.Id));
 
             return Task.FromResult<IEnumerable<FeatureEntry>>(loadedFeatures);
         }


### PR DESCRIPTION
@Jetski5822 

So, just to show the ideas because e.g the assemblies collection is not cached.

In your current solution, dependency context don't work on a dyn loaded assembly, so you only return your entryAssembly. So you provide much less Types (259) but not enough because only related to the modules main assemblies, not their dyn loaded dependencies (e.g a non ambient core project).

Here, i also show the idea about right compilation references. I have more references (about 340), those related to the netcoreapp which are not included in netlibrary.

Note: maybe some mistakes because quickly redone.

**UPDATE**: important to have `preserveCompilationContext`, only for `Orchard.Cms.Web`.


----

Note: i found a way to retrieve primary mvc assemblies (not in this PR) in place of having an hard coded list, this by using a recursive `GetReferencedAssemblies()` on the `Microsoft.AspNetCore.Mvc` assembly and only on its dependency which starts with `Microsoft.AspNetCore.Mvc`. But it adds a little overhead so not in this PR (but if it is cached why not). But i still had 2 missing assemblies.

            "Microsoft.AspNetCore.Mvc.Formatters.Xml",
            "Microsoft.AspNetCore.Mvc.Localization",

But there is an issue on github where they say

> We don't have an IMvcBuilder startup exp for Localizations and xml formatters

So, because `GetReferencedAssemblies()` doesn't retrieve dependencies which are not used, maybe normal to still provide types for these 2 assemblies. So, if we keep the hard coded list, maybe we would have to remove these 2 assemblies from the list. But not sure and i think it is not so important, will see.

Best.