### PR TITLE
Cached shapes delegates was holding references on strategy instances.

### DIFF
--- a/src/Orchard.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
@@ -33,7 +33,6 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeAttributeStrategy
 
 
         private readonly ITypeFeatureProvider _typeFeatureProvider;
-        private readonly IServiceProvider _serviceProvider;
         private readonly IEnumerable<IShapeAttributeProvider> _shapeProviders;
 
         public ShapeAttributeBindingStrategy(
@@ -41,7 +40,6 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeAttributeStrategy
             ITypeFeatureProvider typeFeatureProvider,
             IEnumerable<IShapeAttributeProvider> shapeProviders)
         {
-            _serviceProvider = serviceProvider;
             _typeFeatureProvider = typeFeatureProvider;
             _shapeProviders = shapeProviders;
         }
@@ -87,13 +85,13 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeAttributeStrategy
         {
             return context =>
             {
-                var serviceInstance = _serviceProvider.GetService(attributeOccurrence.ServiceType);
+                var serviceInstance = context.ServiceProvider.GetService(attributeOccurrence.ServiceType);
                 // oversimplification for the sake of evolving
                 return PerformInvokeAsync(context, attributeOccurrence.MethodInfo, serviceInstance);
             };
         }
 
-        private Task<IHtmlContent> PerformInvokeAsync(DisplayContext displayContext, MethodInfo methodInfo, object serviceInstance)
+        private static Task<IHtmlContent> PerformInvokeAsync(DisplayContext displayContext, MethodInfo methodInfo, object serviceInstance)
         {
             var parameters = _parameters.GetOrAdd(methodInfo, m => m.GetParameters());
             var arguments = parameters.Select(parameter => BindParameter(displayContext, parameter));
@@ -129,7 +127,7 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeAttributeStrategy
             return invoke != null ? new HtmlString(invoke.ToString()) : null;
         }
 
-        private object BindParameter(DisplayContext displayContext, ParameterInfo parameter)
+        private static object BindParameter(DisplayContext displayContext, ParameterInfo parameter)
         {
             if (String.Equals(parameter.Name, "Shape", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/HarvestShapeInfo.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/HarvestShapeInfo.cs
@@ -4,6 +4,6 @@
     {
         public string SubPath { get; set; }
         public string FileName { get; set; }
-        public string TemplateVirtualPath { get; set; }
+        public string RelativePath { get; set; }
     }
 }

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/HarvestShapeInfo.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/HarvestShapeInfo.cs
@@ -5,5 +5,6 @@
         public string SubPath { get; set; }
         public string FileName { get; set; }
         public string RelativePath { get; set; }
+        public string Extension { get; set; }
     }
 }

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/IShapeTemplateViewEngine.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/IShapeTemplateViewEngine.cs
@@ -1,10 +1,13 @@
-﻿using Orchard.DependencyInjection;
+﻿using System.Threading.Tasks;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Html;
+using Orchard.DisplayManagement.Implementation;
 
 namespace Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy
 {
     public interface IShapeTemplateViewEngine
     {
         IEnumerable<string> TemplateFileExtensions { get; }
+        Task<IHtmlContent> RenderAsync(string relativePath, DisplayContext displayContext);
     }
 }

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -158,11 +158,15 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy
                             feature.Id);
                     }
 
+                    var viewEngine = _shapeTemplateViewEngines
+                        .FirstOrDefault(e => e.TemplateFileExtensions.Contains(
+                            Path.GetExtension(iter.shapeContext.harvestShapeInfo.RelativePath)));
+
                     builder.Describe(iter.shapeContext.harvestShapeHit.ShapeType)
                         .From(feature)
                         .BoundAs(
                             hit.shapeContext.harvestShapeInfo.RelativePath, shapeDescriptor => displayContext =>
-                                RenderAsync(hit.shapeContext.harvestShapeInfo.RelativePath, displayContext));
+                                viewEngine.RenderAsync(hit.shapeContext.harvestShapeInfo.RelativePath, displayContext));
                 }
             }
 
@@ -170,13 +174,6 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy
             {
                 _logger.LogInformation("Done discovering shapes");
             }
-        }
-
-        private static async Task<IHtmlContent> RenderAsync(string relativePath, DisplayContext displayContext)
-        {
-            return await displayContext.ServiceProvider.GetService<IEnumerable<IShapeTemplateViewEngine>>()
-                .FirstOrDefault(e => e.TemplateFileExtensions.Contains(Path.GetExtension(relativePath)))
-                .RenderAsync(relativePath, displayContext);
         }
     }
 }

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -88,7 +88,7 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy
 
             foreach (var extension in _viewEnginesByExtension.Select(kvp => kvp.Key))
             {
-                matcher.AddInclude(string.Format("*{0}", extension));
+                matcher.AddInclude("*" + extension);
             }
 
             var hits = activeExtensions.Select(extensionDescriptor =>

--- a/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -86,7 +86,7 @@ namespace Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy
                 }
             }
 
-            foreach (var extension in _viewEnginesByExtension.Select(kvp => kvp.Key))
+            foreach (var extension in _viewEnginesByExtension.Keys)
             {
                 matcher.AddInclude("*" + extension);
             }

--- a/src/Orchard.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
+++ b/src/Orchard.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
@@ -1,15 +1,90 @@
-﻿using Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orchard.DisplayManagement.Descriptors.ShapeTemplateStrategy;
+using Orchard.DisplayManagement.Implementation;
 
 namespace Orchard.DisplayManagement.Razor
 {
     public class RazorShapeTemplateViewEngine : IShapeTemplateViewEngine
     {
+        private readonly IOptions<MvcViewOptions> _viewEngine;
+
+        public RazorShapeTemplateViewEngine(
+            IOptions<MvcViewOptions> options)
+        {
+            _viewEngine = options;
+        }
+
         public IEnumerable<string> TemplateFileExtensions
         {
-            get {
-                return new[] { "cshtml" };
+            get
+            {
+                return new[] { ".cshtml" };
             }
+        }
+
+        public async Task<IHtmlContent> RenderAsync(string relativePath, DisplayContext displayContext)
+        {
+            var viewName = "/" + relativePath;
+
+            if (displayContext.ViewContext.View != null)
+            {
+                var htmlHelper = MakeHtmlHelper(displayContext.ViewContext, displayContext.ViewContext.ViewData);
+                return htmlHelper.Partial(viewName, displayContext.Value);
+            }
+            else
+            {
+                // If the View is null, it means that the shape is being executed from a non-view origin / where no ViewContext was established by the view engine, but manually.
+                // Manually creating a ViewContext works when working with Shape methods, but not when the shape is implemented as a Razor view template.
+                // Horrible, but it will have to do for now.
+                return await RenderRazorViewAsync(viewName, displayContext);
+            }
+        }
+
+        private async Task<IHtmlContent> RenderRazorViewAsync(string viewName, DisplayContext context)
+        {
+            var viewEngineResult = _viewEngine.Value.ViewEngines.First().FindView(context.ViewContext, viewName, isMainPage: false);
+            if (viewEngineResult.Success)
+            {
+                var bufferScope = context.ViewContext.HttpContext.RequestServices.GetRequiredService<IViewBufferScope>();
+                var viewBuffer = new ViewBuffer(bufferScope, viewEngineResult.ViewName, ViewBuffer.PartialViewPageSize);
+                using (var writer = new ViewBufferTextWriter(viewBuffer, context.ViewContext.Writer.Encoding))
+                {
+                    // Forcing synchronous behavior so users don't have to await templates.
+                    var view = viewEngineResult.View;
+                    using (view as IDisposable)
+                    {
+                        var viewContext = new ViewContext(context.ViewContext, viewEngineResult.View, context.ViewContext.ViewData, writer);
+                        await viewEngineResult.View.RenderAsync(viewContext);
+                        return viewBuffer;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static IHtmlHelper MakeHtmlHelper(ViewContext viewContext, ViewDataDictionary viewData)
+        {
+            var newHelper = viewContext.HttpContext.RequestServices.GetRequiredService<IHtmlHelper>();
+
+            var contextable = newHelper as IViewContextAware;
+            if (contextable != null)
+            {
+                var newViewContext = new ViewContext(viewContext, viewContext.View, viewData, viewContext.Writer);
+                contextable.Contextualize(newViewContext);
+            }
+
+            return newHelper;
         }
     }
 }

--- a/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
+++ b/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
@@ -23,66 +23,66 @@ using Orchard.Environment.Extensions.Features;
 
 namespace Orchard.DisplayManagement
 {
-	public static class ServiceCollectionExtensions
-	{
-		/// <summary>
-		/// Adds host level services.
-		/// </summary>
-		/// <param name="services"></param>
-		/// <returns></returns>
-		public static IServiceCollection AddThemingHost(this IServiceCollection services)
-		{
-			services.AddTransient<IMvcRazorHost, ShapeRazorHost>();
-			services.AddScoped<IModelUpdaterAccessor, LocalModelBinderAccessor>();
-			services.AddScoped<IFilterMetadata, ModelBinderAccessorFilter>();
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds host level services.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddThemingHost(this IServiceCollection services)
+        {
+            services.AddTransient<IMvcRazorHost, ShapeRazorHost>();
+            services.AddScoped<IModelUpdaterAccessor, LocalModelBinderAccessor>();
+            services.AddScoped<IFilterMetadata, ModelBinderAccessorFilter>();
 
-			services.AddScoped<IViewLocationExpanderProvider, DefaultViewLocationExpanderProvider>();
-			services.AddScoped<IViewLocationExpanderProvider, ModuleViewLocationExpanderProvider>();
-			services.AddScoped<IViewLocationExpanderProvider, ThemeAwareViewLocationExpanderProvider>();
+            services.AddScoped<IViewLocationExpanderProvider, DefaultViewLocationExpanderProvider>();
+            services.AddScoped<IViewLocationExpanderProvider, ModuleViewLocationExpanderProvider>();
+            services.AddScoped<IViewLocationExpanderProvider, ThemeAwareViewLocationExpanderProvider>();
 
-			services.AddSingleton<IExtensionDependencyStrategy, ThemeExtensionDependencyStrategy>();
+            services.AddSingleton<IExtensionDependencyStrategy, ThemeExtensionDependencyStrategy>();
+            services.AddScoped<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
 
-			services.Configure<RazorViewEngineOptions>(options =>
-			{
-				options.FileProviders.Add(new ThemingFileProvider());
-				options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
-			});
+            services.Configure<RazorViewEngineOptions>(options =>
+            {
+                options.FileProviders.Add(new ThemingFileProvider());
+                options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
+            });
 
-			services.AddSingleton<IFeatureBuilderEvents, ThemeFeatureBuilderEvents>();
+            services.AddSingleton<IFeatureBuilderEvents, ThemeFeatureBuilderEvents>();
 
-			return services;
-		}
+            return services;
+        }
 
-		public static IServiceCollection AddTheming(this IServiceCollection services)
-		{
-			services.AddScoped<IShapeTemplateHarvester, BasicShapeTemplateHarvester>();
-			services.AddScoped<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
-			services.AddTransient<IShapeTableManager, DefaultShapeTableManager>();
+        public static IServiceCollection AddTheming(this IServiceCollection services)
+        {
+            services.AddScoped<IShapeTemplateHarvester, BasicShapeTemplateHarvester>();
+            services.AddTransient<IShapeTableManager, DefaultShapeTableManager>();
 
-			services.AddScoped<IShapeTableProvider, ShapeAttributeBindingStrategy>();
-			services.AddScoped<IShapeTableProvider, ShapePlacementParsingStrategy>();
-			services.AddScoped<IShapeTableProvider, ShapeTemplateBindingStrategy>();
+            services.AddScoped<IShapeTableProvider, ShapeAttributeBindingStrategy>();
+            services.AddScoped<IShapeTableProvider, ShapePlacementParsingStrategy>();
+            services.AddScoped<IShapeTableProvider, ShapeTemplateBindingStrategy>();
 
-			services.AddShapeAttributes<CoreShapes>();
-			services.AddScoped<IShapeTableProvider, CoreShapesTableProvider>();
-			services.AddShapeAttributes<ZoneShapes>();
-			services.AddScoped<IShapeTableProvider, LayoutShapes>();
+            services.AddShapeAttributes<CoreShapes>();
+            services.AddScoped<IShapeTableProvider, CoreShapesTableProvider>();
+            services.AddShapeAttributes<ZoneShapes>();
+            services.AddScoped<IShapeTableProvider, LayoutShapes>();
 
-			services.AddScoped<IHtmlDisplay, DefaultHtmlDisplay>();
-			services.AddScoped<ILayoutAccessor, LayoutAccessor>();
-			services.AddScoped<IThemeManager, ThemeManager>();
-			services.AddScoped<IPageTitleBuilder, PageTitleBuilder>();
+            services.AddScoped<IHtmlDisplay, DefaultHtmlDisplay>();
+            services.AddScoped<ILayoutAccessor, LayoutAccessor>();
+            services.AddScoped<IThemeManager, ThemeManager>();
+            services.AddScoped<IPageTitleBuilder, PageTitleBuilder>();
 
-			services.AddScoped<IShapeFactory, DefaultShapeFactory>();
-			services.AddScoped<IDisplayHelperFactory, DisplayHelperFactory>();
+            services.AddScoped<IShapeFactory, DefaultShapeFactory>();
+            services.AddScoped<IDisplayHelperFactory, DisplayHelperFactory>();
 
-			services.AddScoped<INotifier, Notifier>();
-			services.AddScoped<IFilterMetadata, NotifyFilter>();
+            services.AddScoped<INotifier, Notifier>();
+            services.AddScoped<IFilterMetadata, NotifyFilter>();
 
-			services.AddScoped(typeof(IPluralStringLocalizer<>), typeof(PluralStringLocalizer<>));
-			services.AddShapeAttributes<DateTimeShapes>();
+            services.AddScoped(typeof(IPluralStringLocalizer<>), typeof(PluralStringLocalizer<>));
+            services.AddShapeAttributes<DateTimeShapes>();
 
-			return services;
-		}
-	}
+            return services;
+        }
+    }
 }

--- a/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
+++ b/src/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ namespace Orchard.DisplayManagement
             services.AddScoped<IViewLocationExpanderProvider, ThemeAwareViewLocationExpanderProvider>();
 
             services.AddSingleton<IExtensionDependencyStrategy, ThemeExtensionDependencyStrategy>();
-            services.AddScoped<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
+            services.AddSingleton<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
 
             services.Configure<RazorViewEngineOptions>(options =>
             {


### PR DESCRIPTION
Because a shape is cached in a static dictionary and uses a delegate which invokes a method of a binding strategy object instance which has a scoped lifetime, the shape holds a reference on this object.

- For one strategy i could simply make the method static.

- For the template strategy i made a RenderAsync() static method which resolves, through the displayContext.ServiceProvider, the right view engine service instance to render the shape.

Please see if i did it the right way.

Best.