### PR TITLE
#571: Solves Shapes conflicts.

### DIFF
--- a/src/Orchard.DisplayManagement/Descriptors/ShapeDescriptor.cs
+++ b/src/Orchard.DisplayManagement/Descriptors/ShapeDescriptor.cs
@@ -49,7 +49,8 @@ namespace Orchard.DisplayManagement.Descriptors
         {
             get
             {
-                return Bindings[ShapeType].BindingAsync;
+                ShapeBinding binding;
+                return Bindings.TryGetValue(ShapeType, out binding) ? binding.BindingAsync : null;
             }
         }
 
@@ -57,8 +58,8 @@ namespace Orchard.DisplayManagement.Descriptors
         {
             get
             {
-                return _alterationKeys.Select(key => _descriptors[key])
-                    .SelectMany(sd => sd.Bindings).GroupBy(kv => kv.Key).Select(kv => kv.Last())
+                return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.Bindings)
+                    .GroupBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase).Select(kv => kv.Last())
                     .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
             }
         }


### PR DESCRIPTION
Fixes #571 

In fact, bindings were already correctly grouped by binding names before populating a dictionary. But we also need to use a case insensitive comparer when grouping, as it is used by the final dictionary.