### PR TITLE
Work on staticmodular

### DIFF
--- a/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules.Abstractions/IModularAssemblyProvider.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNetCore.Modules
 {
     public interface IModularAssemblyProvider
     {
-        IEnumerable<Assembly> GetAssemblies();
+        IEnumerable<Assembly> GetAssemblies(ISet<string> referenceAssemblies);
     }
 }

--- a/src/Microsoft.AspNetCore.Modules/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Modules/Extensions/ModularServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ namespace Microsoft.AspNetCore.Modules
                 internalServices.AddExtensionManagerHost("App_Data", "dependencies");
 
                 internalServices.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                internalServices.AddScoped<IModularAssemblyProvider, ModularAssemblyProvider>();
             });
         }
     }

--- a/src/Microsoft.AspNetCore.Modules/ModularAssemblyProvider.cs
+++ b/src/Microsoft.AspNetCore.Modules/ModularAssemblyProvider.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Orchard.Environment.Shell.Builders.Models;
+
+namespace Microsoft.AspNetCore.Modules
+{
+    public class ModularAssemblyProvider : IModularAssemblyProvider
+    {
+        private readonly ShellBlueprint _shellBlueprint;
+
+        public ModularAssemblyProvider(ShellBlueprint shellBlueprint)
+        {
+            _shellBlueprint = shellBlueprint;
+        }
+
+        private IList<Assembly> CachedAssemblies;
+
+        // Returns a list of assemblies and their dependencies contained in runtimeAssemblies
+        public IEnumerable<Assembly> GetAssemblies(ISet<string> referenceAssemblies)
+        {
+            if (CachedAssemblies == null)
+            {
+                if (!referenceAssemblies.Any())
+                {
+                    return Enumerable.Empty<Assembly>();
+                }
+
+                var dependencies = new List<Assembly>();
+                var references = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                var assemblies = _shellBlueprint.Dependencies.Keys
+                    .Select(x => x.GetTypeInfo().Assembly)
+                    .Distinct();
+
+                foreach (var assembly in assemblies)
+                {
+                    dependencies.AddRange(AddReferences(assembly, references));
+                }
+
+                CachedAssemblies = DefaultAssemblyDiscoveryProvider
+                    .GetCandidateAssemblies(dependencies, referenceAssemblies)
+                    .ToList();
+            }
+
+            return CachedAssemblies;
+        }
+
+        internal IEnumerable<Assembly> AddReferences(Assembly assembly, HashSet<string> references)
+        {
+            if (references.Add(assembly.GetName().Name))
+            {
+                yield return assembly;
+            }
+
+            foreach (var assemblyName in assembly.GetReferencedAssemblies())
+            {
+                if (references.Add(assemblyName.Name))
+                {
+                    var referenced = Assembly.Load(assemblyName);
+                    AddReferences(referenced, references);
+                    yield return referenced;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
@@ -101,16 +101,5 @@ namespace Microsoft.AspNetCore.Mvc.Modules
             services.Replace(
                 ServiceDescriptor.Transient<ITagHelperTypeResolver, FeatureTagHelperTypeResolver>());
         }
-
-        private static MetadataReference CreateMetadataReference(string path)
-        {
-            using (var stream = File.OpenRead(path))
-            {
-                var moduleMetadata = ModuleMetadata.CreateFromStream(stream, PEStreamOptions.PrefetchMetadata);
-                var assemblyMetadata = AssemblyMetadata.Create(moduleMetadata);
-
-                return assemblyMetadata.GetReference(filePath: path);
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Modules/ShellFeatureApplicationPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/ShellFeatureApplicationPart.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
-
 using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.AspNetCore.Mvc.Modules

--- a/src/Microsoft.AspNetCore.Mvc.Modules/ShellFeatureApplicationPart.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Modules/ShellFeatureApplicationPart.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Loader;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.DependencyInjection;
-using Orchard.Environment.Extensions;
-using Orchard.Environment.Shell.Builders.Models;
+
+using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.AspNetCore.Mvc.Modules
 {
@@ -20,15 +19,29 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         IApplicationPartTypeProvider,
         ICompilationReferencesProvider
     {
+        internal static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Microsoft.AspNetCore.Mvc",
+            "Microsoft.AspNetCore.Mvc.Abstractions",
+            "Microsoft.AspNetCore.Mvc.ApiExplorer",
+            "Microsoft.AspNetCore.Mvc.Core",
+            "Microsoft.AspNetCore.Mvc.Cors",
+            "Microsoft.AspNetCore.Mvc.DataAnnotations",
+            "Microsoft.AspNetCore.Mvc.Formatters.Json",
+            "Microsoft.AspNetCore.Mvc.Formatters.Xml",
+            "Microsoft.AspNetCore.Mvc.Localization",
+            "Microsoft.AspNetCore.Mvc.Razor",
+            "Microsoft.AspNetCore.Mvc.Razor.Host",
+            "Microsoft.AspNetCore.Mvc.RazorPages",
+            "Microsoft.AspNetCore.Mvc.TagHelpers",
+            "Microsoft.AspNetCore.Mvc.ViewFeatures"
+        };
 
-		private static IEnumerable<string> _referencePaths;
-		private static object _synLock = new object();
-
-		/// <summary>
-		/// Initalizes a new <see cref="AssemblyPart"/> instance.
-		/// </summary>
-		/// <param name="assembly"></param>
-		public ShellFeatureApplicationPart(IHttpContextAccessor httpContextAccessor)
+        /// <summary>
+        /// Initalizes a new <see cref="AssemblyPart"/> instance.
+        /// </summary>
+        /// <param name="assembly"></param>
+        public ShellFeatureApplicationPart(IHttpContextAccessor httpContextAccessor)
         {
             if (httpContextAccessor == null)
             {
@@ -42,11 +55,8 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         /// Gets the <see cref="IHttpContextAccessor"/> of the <see cref="ApplicationPart"/>.
         /// </summary>
         public IHttpContextAccessor HttpContextAccessor { get; }
-		private IModularAssemblyProvider AssemblyProvider =>
-			HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IModularAssemblyProvider>();
-
-		private ShellBlueprint ShellBlueprint =>
-            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<ShellBlueprint>();
+        private IModularAssemblyProvider ModularAssemblyProvider =>
+            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IModularAssemblyProvider>();
 
         public override string Name
         {
@@ -61,56 +71,17 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         {
             get
             {
-                return ShellBlueprint.Dependencies.Keys.Select(type => type.GetTypeInfo());
+                return ModularAssemblyProvider
+                    .GetAssemblies(ReferenceAssemblies)
+                    .SelectMany(x => x.DefinedTypes);
             }
         }
 
-		/// <inheritdoc />
-		public IEnumerable<string> GetReferencePaths()
-		{
-			if (_referencePaths != null)
-			{
-				return _referencePaths;
-			}
-
-			lock (_synLock)
-			{
-				if (_referencePaths != null)
-				{
-					return _referencePaths;
-				}
-
-				var referenceAssemblies = new HashSet<Assembly>();
-				var extensionManager = HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IExtensionManager>();
-				foreach (var extension in extensionManager.GetExtensions())
-				{
-					var extensionAssembly = Assembly.Load(new AssemblyName(extension.Id));
-					PopulateAssemblies(extensionAssembly, referenceAssemblies);
-				}
-
-				_referencePaths = referenceAssemblies.Select(x => x.Location).ToArray();
-			}
-
-			return _referencePaths;
-		}
-
-		private void PopulateAssemblies(Assembly assembly, HashSet<Assembly> assemblies)
-		{
-			assemblies.Add(assembly);
-			var loadContext = AssemblyLoadContext.GetLoadContext(assembly);
-			var referencedAssemblyNames = assembly.GetReferencedAssemblies();
-
-			foreach (var referencedAssemblyName in referencedAssemblyNames)
-			{
-				var referencedAssembly = loadContext.LoadFromAssemblyName(referencedAssemblyName);
-
-				if (assemblies.Contains(referencedAssembly))
-				{
-					continue;
-				}
-
-				PopulateAssemblies(referencedAssembly, assemblies);
-			}
-		}
+        /// <inheritdoc />
+        public IEnumerable<string> GetReferencePaths()
+        {
+            return DependencyContext.Default.CompileLibraries
+                .SelectMany(library => library.ResolveReferencePaths());
+        }
     }
-} 
+}

--- a/src/Microsoft.AspNetCore.Nancy.Modules/AssemblyCatalogs/AmbientAssemblyCatalog.cs
+++ b/src/Microsoft.AspNetCore.Nancy.Modules/AssemblyCatalogs/AmbientAssemblyCatalog.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Nancy;
-using Orchard.Environment.Shell.Builders.Models;
 
 namespace Microsoft.AspNetCore.Nancy.Modules.AssemblyCatalogs
 {
@@ -35,8 +34,8 @@ namespace Microsoft.AspNetCore.Nancy.Modules.AssemblyCatalogs
         /// </summary>
         public IHttpContextAccessor HttpContextAccessor { get; }
 
-        private ShellBlueprint ShellBlueprint =>
-            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<ShellBlueprint>();
+        private IModularAssemblyProvider ModularAssemblyProvider =>
+            HttpContextAccessor.HttpContext.RequestServices.GetRequiredService<IModularAssemblyProvider>();
 
         /// <summary>
         /// Gets all <see cref="Assembly"/> instances in the catalog.
@@ -44,11 +43,9 @@ namespace Microsoft.AspNetCore.Nancy.Modules.AssemblyCatalogs
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
         public IReadOnlyCollection<Assembly> GetAssemblies()
         {
-            return DefaultAssemblyDiscoveryProvider
-                    .DiscoverAssemblies(
-                        ShellBlueprint.Dependencies.Select(dep => dep.Key.GetTypeInfo().Assembly).Distinct().ToList(),
-                        ReferenceAssemblies)
-                    .ToArray();
+            return ModularAssemblyProvider
+                .GetAssemblies(ReferenceAssemblies)
+                .ToArray();
         }
     }
 }

--- a/src/Orchard.Environment.Extensions/ExtensionManager.cs
+++ b/src/Orchard.Environment.Extensions/ExtensionManager.cs
@@ -136,16 +136,23 @@ namespace Orchard.Environment.Extensions
 
         public Task<IEnumerable<FeatureEntry>> LoadFeaturesAsync()
         {
-            EnsureInitialized();
+            var orderedFeaturesIds = GetFeatures().Select(f => f.Id).ToList();
 
-            return Task.FromResult<IEnumerable<FeatureEntry>>(_features.Values);
+            var loadedFeatures = _features.Values
+                .OrderBy(f => orderedFeaturesIds.IndexOf(f.FeatureInfo.Id));
+
+            return Task.FromResult<IEnumerable<FeatureEntry>>(loadedFeatures);
         }
 
         public Task<IEnumerable<FeatureEntry>> LoadFeaturesAsync(string[] featureIdsToLoad)
         {
             EnsureInitialized();
 
-            var loadedFeatures = _features.Values.Where(f => featureIdsToLoad.Contains(f.FeatureInfo.Id));
+            var orderedFeaturesIds = GetFeatures().Select(f => f.Id).ToList();
+
+            var loadedFeatures = _features.Values
+                .Where(f => featureIdsToLoad.Contains(f.FeatureInfo.Id))
+                .OrderBy(f => orderedFeaturesIds.IndexOf(f.FeatureInfo.Id));
 
             return Task.FromResult<IEnumerable<FeatureEntry>>(loadedFeatures);
         }


### PR DESCRIPTION
Just to show a solution which works on my side. So, quickly done and, in this new context, it's a mix of many works nick already did and some fixes in my other PR. E.g i re-introduced `ModularAssemblyProvider` but the stuff can be done elsewhere, and i've copied / pasted in the current `DefaultAssemblyDiscoveryProvider` what was done in my other PR but in a separate `DefaultModularAssemblyDiscoveryProvider.cs` file.

---

**Types**

Here i still use shell assemblies and their dependencies grabbed by using `GetReferencedAssemblies()`. This because, here also, `DependencyContext.Load(a)` only works on the main app assembly. And we still need to grab dependencies, not only features main assemblies. Otherwise **you don't get enough types**.

Then in place of just using our dyn loaded assemblies, i take into account all the above dependencies and then filter them to those which reference a primary mvc assembly, otherwise you get **20000 types**.

Then i get about **1760 types**.

---

**References**

Here i've just removed the compilation references related to our dyn loaded assemblies which don't exist anymore. Then, for razor compilation purpose, i still provide the main dependency context compilation references which now contain all modules and their dependencies (framework ones included).

So right now, references are not filtered according to the shell, **but it's just for razor compilation** and i have only **300 references**. But i you want we could filter them by using the names of all features dependencies already grabbed for Types (but here not filtered to those which reference primary mvc assemblies).

But i think it's important to filter Types by shell features but not compilation ReferencesPaths. So, here the idea would be to **cache and always provide to all tenants the same list of about 300 references**.

**Note**: i also included a temporary fix but only due to some changes related to some works in progress. It is related to blueprint feature ordering, so, just to get it fully working, [as done in my other PR](https://github.com/OrchardCMS/Orchard2/pull/568/commits/e579b09aa6fe210f81a13fe72a6c298eaba0bddb).

Best.
