### PR TITLE
Fix services.AddMvcModules() to register the MVC authorization filter

### DIFF
--- a/src/OrchardCore/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Mvc.Modules/Extensions/ModularServiceCollectionExtensions.cs
@@ -34,13 +34,15 @@ namespace Microsoft.AspNetCore.Mvc.Modules
         public static IServiceCollection AddMvcModules(this IServiceCollection services,
             IServiceProvider applicationServices)
         {
-            var builder = services.AddMvcCore(options => {
+            var builder = services.AddMvcCore(options =>
+            {
                 // Do we need this?
                 options.Filters.Add(typeof(AutoValidateAntiforgeryTokenAuthorizationFilter));
 
                 options.ModelBinderProviders.Insert(0, new CheckMarkModelBinderProvider());
             });
 
+            builder.AddAuthorization();
             builder.AddViews();
             builder.AddViewLocalization();
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard2/issues/600.