### PR TITLE
Ensure AuthenticationTicket.SetResources() is not called for authorization code/refresh token requests

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.OpenId/Controllers/AccessController.cs
@@ -18,8 +18,8 @@ using Microsoft.Extensions.Options;
 using OpenIddict.Core;
 using Orchard.OpenId.Models;
 using Orchard.OpenId.ViewModels;
-using Orchard.Users.Models;
 using Orchard.Security;
+using Orchard.Users.Models;
 
 namespace Orchard.OpenId.Controllers
 {
@@ -515,9 +515,9 @@ namespace Orchard.OpenId.Controllers
                     OpenIdConnectConstants.Scopes.OfflineAccess,
                     OpenIddictConstants.Scopes.Roles
                 }.Intersect(request.GetScopes()));
-            }
 
-            ticket.SetResources(request.GetResources());
+                ticket.SetResources(request.GetResources());
+            }
 
             // Note: by default, claims are NOT automatically included in the access and identity tokens.
             // To allow OpenIddict to serialize them, you must attach them a destination, that specifies

--- a/src/Orchard.Cms.Web/Modules/Orchard.OpenId/Migrations.cs
+++ b/src/Orchard.Cms.Web/Modules/Orchard.OpenId/Migrations.cs
@@ -14,7 +14,7 @@ namespace Orchard.OpenId
 
             SchemaBuilder.CreateMapIndexTable(nameof(OpenIdTokenIndex), table => table
                 .Column<int>(nameof(OpenIdTokenIndex.AppId))
-                .Column<int>(nameof(OpenIdTokenIndex.Subject))
+                .Column<string>(nameof(OpenIdTokenIndex.Subject))
                 .Column<int>(nameof(OpenIdTokenIndex.TokenId)));
 
             return 1;


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard2/issues/620.