### PR TITLE
Enabled Orchard.HomeRoute module in SaaS recipe

### DIFF
--- a/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/saas.recipe.json
+++ b/src/Orchard.Cms.Web/Modules/Orchard.Setup/Recipes/saas.recipe.json
@@ -19,6 +19,7 @@
         "Orchard.Commons",
         "Orchard.Diagnostics",
         "Orchard.DynamicCache",
+        "Orchard.HomeRoute",
         "Orchard.Modules",
         "Orchard.Navigation",
         "Orchard.OpenId",


### PR DESCRIPTION
This recipe set HomeRoute in settings, however how it didn't enabled Orchard.HomeRoute the homeroute didn't have any effect and after Setup a Not Found was received. This PR fix that.