### PR TITLE
Added .editorconfig file with definition of project coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,47 @@
+root = true
+
+[*]
+end_of_line = crlf
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types                   = true : suggestion
+csharp_style_var_when_type_is_apparent                = true : suggestion
+csharp_style_var_elsewhere                            = true : suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace                     = all
+csharp_new_line_before_else                           = true
+csharp_new_line_before_catch                          = true
+csharp_new_line_before_finally                        = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types     = true
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first                        = false
+
+# Avoid "this." if not necessary
+dotnet_style_qualification_for_field                       = false : suggestion
+dotnet_style_qualification_for_property                    = false : suggestion
+dotnet_style_qualification_for_method                      = false : suggestion
+dotnet_style_qualification_for_event                       = false : suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true : suggestion
+dotnet_style_predefined_type_for_member_access             = true : suggestion
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true : none
+csharp_style_pattern_matching_over_as_with_null_check = true : none
+csharp_style_inlined_variable_declaration             = true : none
+csharp_style_throw_expression                         = true : none
+csharp_style_conditional_delegate_call                = true : none
+
+dotnet_style_object_initializer                            = true : suggestion
+dotnet_style_collection_initializer                        = true : suggestion
+dotnet_style_coalesce_expression                           = true : suggestion
+dotnet_style_null_propagation                              = true : suggestion
+dotnet_style_explicit_tuple_names                          = true : suggestion


### PR DESCRIPTION
Visual Studio 2017 has support for .editorconfig files, which allow developers to specify coding styles per solution / per project [(Create portable, custom editor settings)](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options). If a developer opens a project with .editorconfig file, his global Visual Studio settings are overridden by styles defined in the .editorconfig. It lowers the entry barrier for new developers, because they might (I am example of such developer) use an other coding style and changing formatting settings whenever they wanted to edit a file in Orchard is quite impractical.

I tried to specify the coding style according to the [
Coding guidelines](https://github.com/OrchardCMS/Orchard2/wiki/Engineering-Guidelines#coding-guidelines). I tested the style on several existing files and it doesn't suggest any crazy reformatting or other changes. So I think it is OK, but feel free to suggest / do any changes.

One question regarding coding styles for regular contributors ... the Engineering-Guidelines document says "Use C# type keywords in favor of .NET type names". I have found several places that breaks this rule. Should I change .Net type names to keywords if I edit the file for some other reason?

