### PR TITLE
Fixes failing on a fresh setup

### DIFF
--- a/src/OrchardCore/Orchard.Environment.Extensions/ExtensionManager.cs
+++ b/src/OrchardCore/Orchard.Environment.Extensions/ExtensionManager.cs
@@ -151,12 +151,11 @@ namespace Orchard.Environment.Extensions
             var orderedFeaturesIds = GetFeatures(featureIdsToLoad).Select(f => f.Id).ToList();
 
             var loadedFeatures = _features.Values
+                .Where(f => orderedFeaturesIds.Contains(f.FeatureInfo.Id))
                 .OrderBy(f => orderedFeaturesIds.IndexOf(f.FeatureInfo.Id));
 
             return Task.FromResult<IEnumerable<FeatureEntry>>(loadedFeatures);
         }
-
-
 
         public IEnumerable<IFeatureInfo> GetFeatureDependencies(string featureId)
         {


### PR DESCRIPTION
In ExtensionManager there was an issue fixed by @Jetski5822 where dependencies of featureIdsToLoad were not taken into account, this when using LoadFeaturesAsync(string[] featureIdsToLoad).

But now all features are returned which breaks the setup. Here we limit them to those that are returned by GetFeatures(featureIdsToLoad).