### PR TITLE
Fixed #551 - Field settings were not updated

### DIFF
--- a/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentBuilderSettings.cs
+++ b/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentBuilderSettings.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Orchard.ContentManagement.Metadata.Builders
+{
+    public static class ContentBuilderSettings
+    {
+        /// <summary>
+        /// Replace current value, even for null values, union arrays.
+        /// </summary>
+        public static readonly JsonMergeSettings JsonMergeSettings = new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union, MergeNullValueHandling = MergeNullValueHandling.Merge };
+    }
+}

--- a/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
@@ -68,7 +68,7 @@ namespace Orchard.ContentManagement.Metadata.Builders
 
         public ContentPartDefinitionBuilder MergeSettings(JObject settings)
         {
-            _settings.Merge(settings, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            _settings.Merge(settings, ContentBuilderSettings.JsonMergeSettings);
             return this;
         }
 

--- a/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentPartFieldDefinitionBuilder.cs
+++ b/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentPartFieldDefinitionBuilder.cs
@@ -28,13 +28,13 @@ namespace Orchard.ContentManagement.Metadata.Builders
 
         public ContentPartFieldDefinitionBuilder MergeSettings(JObject settings)
         {
-            _settings.Merge(settings, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            _settings.Merge(settings, ContentBuilderSettings.JsonMergeSettings);
             return this;
         }
 
         public ContentPartFieldDefinitionBuilder MergeSettings(object model)
         {
-            _settings.Merge(JObject.FromObject(model), new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            _settings.Merge(JObject.FromObject(model), ContentBuilderSettings.JsonMergeSettings);
             return this;
         }
 

--- a/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
+++ b/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
@@ -63,7 +63,7 @@ namespace Orchard.ContentManagement.Metadata.Builders
 
         public ContentTypeDefinitionBuilder MergeSettings(JObject settings)
         {
-            _settings.Merge(settings, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            _settings.Merge(settings, ContentBuilderSettings.JsonMergeSettings);
             return this;
         }
 

--- a/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentTypePartDefinitionBuilder.cs
+++ b/src/OrchardCore/Orchard.ContentManagement.Abstractions/Metadata/Builders/ContentTypePartDefinitionBuilder.cs
@@ -49,7 +49,7 @@ namespace Orchard.ContentManagement.Metadata.Builders
 
         public ContentTypePartDefinitionBuilder MergeSettings(JObject settings)
         {
-            _settings.Merge(settings, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            _settings.Merge(settings, ContentBuilderSettings.JsonMergeSettings);
             return this;
         }
 


### PR DESCRIPTION
Fixes #551. Field settings were not updated if the new value was null or empty string. 

Fixed by changing `JsonMergeSettings.MergeNullValueHandling` to `MergeNullValueHandling.Merge` in content definition builders.