### PR TITLE
Fixes issue with missing prefix in HTML field names

### DIFF
--- a/src/OrchardCore/Orchard.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/Orchard.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -78,6 +78,7 @@ namespace Orchard.DisplayManagement.Implementation
             };
 
             // Use the same prefix as the shape
+            var originalHtmlFieldPrefix = context.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
             context.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = shapeMetadata.Prefix ?? "";
 
             // Evaluate global Shape Display Events
@@ -157,6 +158,9 @@ namespace Orchard.DisplayManagement.Implementation
 
             // invoking ShapeMetadata displayed events
             shapeMetadata.Displayed.Invoke(action => action(displayContext), _logger);
+
+            //restore original HtmlFieldPrefix
+            context.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = originalHtmlFieldPrefix;
 
             return shape.Metadata.ChildContent;
         }


### PR DESCRIPTION
DefaultHtmlDisplay sets HtmlFieldPrefix to the value specified in the shape metadata, but it didn't restore prefix to it's original value. Because the same instance of ViewContext is reused along the whole rendering pipeline, some HTML fields might get generated with wrong prefix. This PR restores HtmlFieldPrefix when the shape is rendered.

This should fix issues with model binding @agriffard has in #650 