### PR TITLE
Implement url layer rule method

### DIFF
--- a/src/OrchardCore.Modules/Orchard.Layers/Services/DefaultLayersMethodProvider.cs
+++ b/src/OrchardCore.Modules/Orchard.Layers/Services/DefaultLayersMethodProvider.cs
@@ -11,6 +11,7 @@ namespace Orchard.Layers.Services
         private readonly GlobalMethod _isHomepage;
         private readonly GlobalMethod _isAnonymous;
         private readonly GlobalMethod _isAuthenticated;
+        private readonly GlobalMethod _url;
 
         private readonly GlobalMethod[] _allMethods;
 
@@ -22,7 +23,8 @@ namespace Orchard.Layers.Services
                 Method = serviceprovider => (Func<string, object>)(name =>
                 {
                     var httpContext = serviceprovider.GetRequiredService<IHttpContextAccessor>().HttpContext;
-                    return httpContext.Request.Path == "/";
+                    var requestPath = httpContext.Request.Path;
+                    return requestPath == "/" || string.IsNullOrEmpty(requestPath);
                 })
             };
 
@@ -35,7 +37,7 @@ namespace Orchard.Layers.Services
                     return !httpContext.User?.Identity.IsAuthenticated;
                 })
             };
-
+            
             _isAuthenticated = new GlobalMethod
             {
                 Name = "isAuthenticated",
@@ -46,7 +48,29 @@ namespace Orchard.Layers.Services
                 })
             };
 
-            _allMethods = new [] { _isAnonymous, _isAuthenticated, _isHomepage };
+            _url = new GlobalMethod
+            {
+                Name = "url",
+                Method = serviceProvider => (Func<string, object>)(url =>
+                {
+                    if (url.StartsWith("~/"))
+                        url = url.Substring(1);
+
+                    var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                    string requestPath = httpContext.Request.Path;
+
+                    // Tenant home page could have an empty string as a request path, where
+                    // the default tenant does not.
+                    if (string.IsNullOrEmpty(requestPath))
+                        requestPath = "/";
+
+                    return url.EndsWith("*")
+                        ? requestPath.StartsWith(url.TrimEnd('*'), StringComparison.OrdinalIgnoreCase)
+                        : string.Equals(requestPath, url, StringComparison.OrdinalIgnoreCase); ;
+                })
+            };
+            
+            _allMethods = new [] { _isAnonymous, _isAuthenticated, _isHomepage, _url };
         }
 
         public IEnumerable<GlobalMethod> GetMethods()


### PR DESCRIPTION
- Added implementation of url('~/somepath*') method. 
- Fixed issue where isHomepage layer rule fails on non default tenants if url was in '/tenant-prefix' and not '/tenant-prefix/' as the request path returns an empty string.