### PR TITLE
Fixing HomePageRoute lifetime issues

### DIFF
--- a/src/OrchardCore.Modules/Orchard.HomeRoute/HomePageRoute.cs
+++ b/src/OrchardCore.Modules/Orchard.HomeRoute/HomePageRoute.cs
@@ -16,16 +16,15 @@ namespace Orchard.HomeRoute
         private RouteValueDictionary _homeRoute;
         private IChangeToken _siteServicechangeToken;
 
-        public HomePageRoute(IHttpContextAccessor httpContextAccessor, IRouteBuilder routeBuilder, IInlineConstraintResolver inlineConstraintResolver)
+        public HomePageRoute(IRouteBuilder routeBuilder, IInlineConstraintResolver inlineConstraintResolver)
             : base(routeBuilder.DefaultHandler, "", inlineConstraintResolver)
         {
-            _httpContextAccessor = httpContextAccessor;
             _routeBuilder = routeBuilder;
         }
 
         protected override async Task OnRouteMatched(RouteContext context)
         {
-            var tokens = GetHomeRouteValues();
+            var tokens = GetHomeRouteValues(context.HttpContext);
 
             if (tokens != null)
             {
@@ -42,7 +41,7 @@ namespace Orchard.HomeRoute
         {
             object value;
 
-            var tokens = GetHomeRouteValues();
+            var tokens = GetHomeRouteValues(context.HttpContext);
 
             if (tokens == null)
             {
@@ -79,11 +78,10 @@ namespace Orchard.HomeRoute
             return result;
         }
 
-        private RouteValueDictionary GetHomeRouteValues()
+        private RouteValueDictionary GetHomeRouteValues(HttpContext httpContext)
         {
             if (_siteServicechangeToken == null || _siteServicechangeToken.HasChanged)
             {
-                var httpContext = _httpContextAccessor.HttpContext;
                 var siteService = httpContext.RequestServices.GetRequiredService<ISiteService>();
                 _homeRoute = siteService.GetSiteSettingsAsync().GetAwaiter().GetResult().HomeRoute;
                 _siteServicechangeToken = siteService.ChangeToken;

--- a/src/OrchardCore.Modules/Orchard.HomeRoute/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.HomeRoute/Startup.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Orchard.Settings;
 
 namespace Orchard.HomeRoute
 {
@@ -12,8 +12,8 @@ namespace Orchard.HomeRoute
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
             var inlineConstraintResolver = serviceProvider.GetService<IInlineConstraintResolver>();
-            var siteService = serviceProvider.GetService<ISiteService>();
-            routes.Routes.Add(new HomePageRoute(siteService, routes, inlineConstraintResolver));
+            var httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();
+            routes.Routes.Add(new HomePageRoute(httpContextAccessor, routes, inlineConstraintResolver));
         }
     }
 }

--- a/src/OrchardCore/Microsoft.AspNetCore.Mvc.Modules.Abstractions/Settings/ISiteService.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Mvc.Modules.Abstractions/Settings/ISiteService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.Extensions.Primitives;
+using System.Threading.Tasks;
 
 namespace Orchard.Settings
 {
@@ -16,5 +17,10 @@ namespace Orchard.Settings
         /// Persists the changes to the site settings.
         /// </summary>
         Task UpdateSiteSettingsAsync(ISite site);
+
+        /// <summary>
+        /// Gets a change token that is set when site settings have changed.
+        /// </summary>
+        IChangeToken ChangeToken { get; }
     }
 }

--- a/src/OrchardCore/Orchard.Environment.Cache/Signal.cs
+++ b/src/OrchardCore/Orchard.Environment.Cache/Signal.cs
@@ -37,7 +37,7 @@ namespace Orchard.Environment.Cache
             }
         }
 
-        private class ChangeTokenInfo
+        private struct ChangeTokenInfo
         {
             public ChangeTokenInfo(IChangeToken changeToken, CancellationTokenSource tokenSource)
             {


### PR DESCRIPTION
ISiteService reference was reused across requests
Improved performance by caching the route directly and
detecting changes using a ChangeToken