### PR TITLE
Startup execution order

### DIFF
--- a/src/OrchardCore.Modules/Orchard.ResponseCache/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.ResponseCache/Startup.cs
@@ -11,6 +11,8 @@ namespace Orchard.ResponseCache
 {
     public class Startup : StartupBase
     {
+        public override int Order => -10;
+
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
             app.UseResponseCaching();

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/IStartup.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/IStartup.cs
@@ -6,16 +6,29 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.AspNetCore.Modules
 {
     /// <summary>
-    /// TODO: After RTM, resolve IStartup using the Application container, but inject tenant services in the Configure method.
+    /// An implementation of this interface is used to initialize the services and HTTP request
+    /// pipeline of a module.
     /// </summary>
     public interface IStartup
     {
         /// <summary>
-        /// Setup application services.
+        /// Get the value to use to order startups. The default is 0.
+        /// </summary>
+        int Order { get; }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         /// </summary>
         /// <param name="services">The collection of service descriptors.</param>
         void ConfigureServices(IServiceCollection services);
 
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="routes"></param>
+        /// <param name="serviceProvider"></param>
         void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider);
     }
 }

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/Startup.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/Startup.cs
@@ -8,15 +8,16 @@ namespace Microsoft.AspNetCore.Modules
     public abstract class StartupBase : IStartup
     {
         /// <inheritdoc />
+        public virtual int Order => 0;
+
+        /// <inheritdoc />
         public virtual void ConfigureServices(IServiceCollection services)
         {
-
         }
 
         /// <inheritdoc />
         public virtual void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-
         }
     }
 }

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantRouterMiddleware.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantRouterMiddleware.cs
@@ -89,7 +89,6 @@ namespace Microsoft.AspNetCore.Modules
 
             // IStartup instances are ordered by module dependency with an Order of 0 by default.
             // OrderBy performs a stable sort so order is preserved among equal Order values.
-
             startups = startups.OrderBy(s => s.Order);
 
             var tenantRouteBuilder = serviceProvider.GetService<IModularTenantRouteBuilder>();
@@ -101,7 +100,6 @@ namespace Microsoft.AspNetCore.Modules
             // the TenantRoute resolution we can create a single Router type that would index the
             // TenantRoute object by their ShellSetting. This way there would just be one lookup.
             // And the ShellSettings test in TenantRoute would also be useless.
-
             foreach (var startup in startups)
             {
                 startup.Configure(appBuilder, routeBuilder, serviceProvider);

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantRouterMiddleware.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantRouterMiddleware.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orchard.Environment.Shell;
 using Orchard.Environment.Shell.Models;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Modules
 {
@@ -85,6 +86,12 @@ namespace Microsoft.AspNetCore.Modules
         public RequestDelegate BuildTenantPipeline(ShellSettings shellSettings, IServiceProvider serviceProvider)
         {
             var startups = serviceProvider.GetServices<IStartup>();
+
+            // IStartup instances are ordered by module dependency with an Order of 0 by default.
+            // OrderBy performs a stable sort so order is preserved among equal Order values.
+
+            startups = startups.OrderBy(s => s.Order);
+
             var tenantRouteBuilder = serviceProvider.GetService<IModularTenantRouteBuilder>();
             
             var appBuilder = new ApplicationBuilder(serviceProvider);


### PR DESCRIPTION
If FeatureA depends on FeatureB, the middlewares and service registrations will be executed first in FeatureB, unless the Startup classes define an Order. A negative Order will run the startups first, and a positive number will run the startups
last.

Fixes #248