### PR TITLE
Working on get rid of the Temp folder for assets files

### DIFF
--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -27,18 +27,16 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CleanPackageAssets" AfterTargets="Clean" Condition="'$(IgnorePackageAssets)' != 'true'">
+  <Target Name="CleanPackageAssets" AfterTargets="Clean" Condition="'$(IgnorePackageAssets)' != 'true' And Exists('$(MSBuildProjectDirectory)\Packages')">
     <ItemGroup>
      <AllPackageAssetFiles
        Include="$(MSBuildProjectDirectory)\Packages\**" />
     </ItemGroup>
     <Delete
       Files="@(AllPackageAssetFiles)"
-      Condition="Exists('$(MSBuildProjectDirectory)\Packages')"
       ContinueOnError="true" />
     <RemoveDir
       Directories="$(MSBuildProjectDirectory)\Packages\%(AllPackageAssetFiles.RecursiveDir)"
-      Condition="Exists('$(MSBuildProjectDirectory)\Packages')"
       ContinueOnError="true" />
   </Target>
 

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -5,22 +5,18 @@
   -->
 
   <Target Name="CopyPackageAssets" AfterTargets="Build" Condition="'$(IgnorePackageAssets)' != 'true'">
-    <ItemGroup>
-      <PackageAssetFiles
-        Include="$(Temp)\OrchardCorePackages\**\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_MSBuildProjectReferenceExistent.Directory)))))\**\*"
-        Condition="'@(_MSBuildProjectReferenceExistent)' != ''" />
-      <ProjectAssetFiles
-        Include="$(MSBuildProjectDirectory)\Packages\**\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_MSBuildProjectReferenceExistent.Directory)))))\**\*"
-        Condition="'@(_MSBuildProjectReferenceExistent)' != ''" />
-    </ItemGroup>
-    <Delete
-      Files="@(ProjectAssetFiles)"
-      Condition="!Exists('$(Temp)\OrchardCorePackages\%(RecursiveDir)%(Filename)%(Extension)')"
-      ContinueOnError="true"/>
     <Message Text="Copying package assets" Importance="high" />
     <Copy
       SourceFiles="@(PackageAssetFiles)"
       DestinationFolder="$(MSBuildProjectDirectory)\Packages\%(RecursiveDir)"
+      ContinueOnError="true" />
+
+    <MSBuild
+      Targets="CopyPackageAssetFiles"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="ApplicationDirectory=$(MSBuildProjectDirectory)"
+      Projects="@(_MSBuildProjectReferenceExistent)"
+      Condition="'@(_MSBuildProjectReferenceExistent)' != '' And (Exists('%(RootDir)%(Directory)Module.txt') Or Exists('%(RootDir)%(Directory)Theme.txt'))"
       ContinueOnError="true" />
 
     <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
@@ -2,7 +2,7 @@
 
   <!-- 
     This file is packaged with OrchardCore.AsModule.nupkg in ./build such that any Module that references
-    it will get its static assets copied to $(Temp)\OrchardCorePackages
+    it will get its static assets copied to $(ApplicationDirectory)\Packages
   -->
 
   <PropertyGroup>
@@ -48,7 +48,7 @@
     <None Include="**\*" Exclude="$(ExcludedFiles)" Pack="true">
       <PackagePath>assets\$(PackageId)\</PackagePath>
     </None>
-    <None Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Module.txt" Pack="true" Condition="!Exists('$(MSBuildProjectDirectory)\Module.txt')">
+    <None Include="Module.txt" Pack="true">
       <PackagePath>assets\$(PackageId)\Module.txt</PackagePath>
     </None>
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
@@ -12,28 +12,31 @@
 
   <ItemGroup>
     <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
-    <TempAssetFiles Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\**\*" />
   </ItemGroup>
 
-  <Target Name="CopyPackageAssetFiles" AfterTargets="Build">
-    <Delete
-      Files="@(TempAssetFiles)"
-      Condition="!Exists('$(MSBuildProjectDirectory)\%(RecursiveDir)%(Filename)%(Extension)')"
-      ContinueOnError="true"/>
-
-    <Message Text="Packaging asset files: $(MSBuildProjectName)" Importance="high" />
-    
-    <Copy
-      SourceFiles="@(PackageAssetFiles)"
-      DestinationFolder="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\%(RecursiveDir)" />
-    
+  <Target Name="CheckManifestFile" AfterTargets="Build">
+    <Message Text="Checking manifest file: $(MSBuildProjectName)" Importance="high" />
     <WriteLinesToFile
-      Condition="!Exists('$(MSBuildProjectDirectory)\Module.txt')"
-      File="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Module.txt"
+      Condition="!Exists('Module.txt')"
+      File="Module.txt"
       Lines="$(ModuleManifest)"
       Overwrite="true"
       Encoding="Unicode"
       ContinueOnError="true" />
+  </Target>
+
+  <Target Name="CopyPackageAssetFiles" Condition="'$(ApplicationDirectory)' != '' And Exists('$(ApplicationDirectory)')">
+    <ItemGroup>
+      <ApplicationAssetFiles Include="$(ApplicationDirectory)\Packages\$(MSBuildProjectName)\**\*" />
+    </ItemGroup>
+    <Delete
+      Files="@(ApplicationAssetFiles)"
+      Condition="!Exists('$(MSBuildProjectDirectory)\%(RecursiveDir)%(Filename)%(Extension)')"
+      ContinueOnError="true"/>
+    <Message Text="Packaging asset files: $(MSBuildProjectName)" Importance="high" />
+    <Copy
+      SourceFiles="@(PackageAssetFiles)"
+      DestinationFolder="$(ApplicationDirectory)\Packages\$(MSBuildProjectName)\%(RecursiveDir)" />
   </Target>
 
   <!-- Adds a custom .props file to the generated module package -->

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
@@ -14,10 +14,9 @@
     <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
   </ItemGroup>
 
-  <Target Name="CheckManifestFile" AfterTargets="Build">
-    <Message Text="Checking manifest file: $(MSBuildProjectName)" Importance="high" />
+  <Target Name="CheckManifestFile" AfterTargets="Build" Condition="!Exists('Module.txt')">
+    <Message Text="Generating manifest file: $(MSBuildProjectName)" Importance="high" />
     <WriteLinesToFile
-      Condition="!Exists('Module.txt')"
       File="Module.txt"
       Lines="$(ModuleManifest)"
       Overwrite="true"

--- a/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
+++ b/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
@@ -14,10 +14,9 @@
     <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
   </ItemGroup>
 
-  <Target Name="CheckManifestFile" AfterTargets="Build">
-    <Message Text="Checking manifest file: $(MSBuildProjectName)" Importance="high" />
+  <Target Name="CheckManifestFile" AfterTargets="Build" Condition="!Exists('Theme.txt')">
+    <Message Text="Generating manifest file: $(MSBuildProjectName)" Importance="high" />
     <WriteLinesToFile
-      Condition="!Exists('Theme.txt')"
       File="Theme.txt"
       Lines="$(ThemeManifest)"
       Overwrite="true"

--- a/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
+++ b/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
@@ -2,7 +2,7 @@
 
   <!--
     This file is packaged with OrchardCore.AsTheme.nupkg in ./build such that any Theme that references
-    it will get its static assets copied to $(Temp)\OrchardCorePackages
+    it will get its static assets copied to $(ApplicationDirectory)\Packages
   -->
 
   <PropertyGroup>
@@ -48,7 +48,7 @@
     <None Include="**\*" Exclude="$(ExcludedFiles)" Pack="true">
       <PackagePath>assets\$(PackageId)\</PackagePath>
     </None>
-    <None Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Theme.txt" Pack="true" Condition="!Exists('$(MSBuildProjectDirectory)\Theme.txt')">
+    <None Include="Theme.txt" Pack="true">
       <PackagePath>assets\$(PackageId)\Theme.txt</PackagePath>
     </None>
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
+++ b/src/OrchardCore/OrchardCore.AsTheme/OrchardCore.AsTheme.props
@@ -12,27 +12,31 @@
 
   <ItemGroup>
     <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
-    <TempAssetFiles Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\**\*" />
   </ItemGroup>
 
-  <Target Name="CopyPackageAssetFiles" AfterTargets="Build">
-    <Delete
-      Files="@(TempAssetFiles)"
-      Condition="!Exists('$(MSBuildProjectDirectory)\%(RecursiveDir)%(Filename)%(Extension)')"
-      ContinueOnError="true"/>
-
-    <Message Text="Packaging asset files: $(MSBuildProjectName)" Importance="high" />
-    <Copy
-      SourceFiles="@(PackageAssetFiles)"
-      DestinationFolder="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\%(RecursiveDir)" />
-
+  <Target Name="CheckManifestFile" AfterTargets="Build">
+    <Message Text="Checking manifest file: $(MSBuildProjectName)" Importance="high" />
     <WriteLinesToFile
-      Condition="!Exists('$(MSBuildProjectDirectory)\Theme.txt')"
-      File="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Theme.txt"
+      Condition="!Exists('Theme.txt')"
+      File="Theme.txt"
       Lines="$(ThemeManifest)"
       Overwrite="true"
       Encoding="Unicode"
       ContinueOnError="true" />
+  </Target>
+
+  <Target Name="CopyPackageAssetFiles" Condition="'$(ApplicationDirectory)' != '' And Exists('$(ApplicationDirectory)')">
+    <ItemGroup>
+      <ApplicationAssetFiles Include="$(ApplicationDirectory)\Packages\$(MSBuildProjectName)\**\*" />
+    </ItemGroup>
+    <Delete
+      Files="@(ApplicationAssetFiles)"
+      Condition="!Exists('$(MSBuildProjectDirectory)\%(RecursiveDir)%(Filename)%(Extension)')"
+      ContinueOnError="true"/>
+    <Message Text="Packaging asset files: $(MSBuildProjectName)" Importance="high" />
+    <Copy
+      SourceFiles="@(PackageAssetFiles)"
+      DestinationFolder="$(ApplicationDirectory)\Packages\$(MSBuildProjectName)\%(RecursiveDir)" />
   </Target>
 
   <!-- Adds a custom .props file to the generated theme package -->
@@ -44,7 +48,7 @@
     <None Include="**\*" Exclude="$(ExcludedFiles)" Pack="true">
       <PackagePath>assets\$(PackageId)\</PackagePath>
     </None>
-        <None Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Theme.txt" Pack="true" Condition="!Exists('$(MSBuildProjectDirectory)\Theme.txt')">
+    <None Include="$(Temp)\OrchardCorePackages\$(MSBuildProjectName)\Theme.txt" Pack="true" Condition="!Exists('$(MSBuildProjectDirectory)\Theme.txt')">
       <PackagePath>assets\$(PackageId)\Theme.txt</PackagePath>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Fixes #702 

See #703 for more details in my comments.
Tested in our solution where modules are referenced as projects.
Todo: Check it still works when modules are referenced as packages.
Update: Done, if a module is referenced as a package, it works as before.