### PR TITLE
Fixes #724 : removing fallback packages

### DIFF
--- a/src/OrchardCore.Build/OrchardCore.Commons.props
+++ b/src/OrchardCore.Build/OrchardCore.Commons.props
@@ -7,7 +7,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net451+win8</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Orchard.Tests/Orchard.Tests.csproj
+++ b/test/Orchard.Tests/Orchard.Tests.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>Orchard.Tests</AssemblyName>
     <PackageId>Orchard.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net451+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
We use netstandard1.6, all out libs depend on that. We dont need the others.