### PR TITLE
Sql Queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,6 @@ csx
 AppPackages/
 
 # Others
-sql/
 *.Cache
 !Orchard.Environment.Cache
 ClientBin/

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,5 +7,6 @@
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="Orchard2" value="https://www.myget.org/F/orchard2/api/v3/index.json" />
     <add key="icunet" value="https://www.myget.org/F/icu-dotnet/api/v3/index.json" />
+    <add key="irony" value="https://www.myget.org/F/daxnet-utils/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
+++ b/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
+++ b/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
+++ b/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
+++ b/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Indexing/Orchard.Indexing.csproj
+++ b/src/OrchardCore.Modules/Orchard.Indexing/Orchard.Indexing.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Indexing/Orchard.Indexing.csproj
+++ b/src/OrchardCore.Modules/Orchard.Indexing/Orchard.Indexing.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
+++ b/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
+++ b/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Lucene/Drivers/LuceneQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Lucene/Drivers/LuceneQueryDisplayDriver.cs
@@ -48,6 +48,12 @@ namespace Orchard.Lucene.Drivers
                 model.Index = query.Index;
                 model.ReturnContentItems = query.ReturnContentItems;
                 model.Indices = _luceneIndexManager.List().ToArray();
+
+                // Extract query from the query string if we come from the main query editor
+                if (string.IsNullOrEmpty(query.Template))
+                {
+                    updater.TryUpdateModelAsync(model, "", m => m.Query);
+                }
             }).Location("Content:5");
         }
 

--- a/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
+++ b/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-alpha" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-alpha" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
+++ b/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-alpha" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-alpha" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Lucene/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Lucene/Views/Admin/Query.cshtml
@@ -55,6 +55,10 @@
 
 @if (Model.Documents.Any())
 {
+    <div class="form-group">
+        <a href="@Url.Action("Create", "Admin", new { area = "Orchard.Queries", id = "Lucene", query = Model.DecodedQuery })" class="btn btn-success">@T["Create"]</a>
+    </div>
+
     <table class="table table-striped table-hover table-responsive">
         <thead>
             <tr>

--- a/src/OrchardCore.Modules/Orchard.Queries/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Controllers/ApiController.cs
@@ -25,18 +25,21 @@ namespace Orchard.Queries.Controllers
             string name,
             string parameters)
         {
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ExecuteQueryApi))
-            {
-                return Unauthorized();
-            }
-
-            var queryParameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(parameters ?? "");
             var query = await _queryManager.GetQueryAsync(name);
 
             if (query == null)
             {
                 return NotFound();
             }
+
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.CreatePermissionForQuery(query.Name)))
+            {
+                // Intentionally not returning Unauthorized as it is not usable from APIs and would
+                // expose the existence of a named query (not a concern per se).
+                return NotFound();
+            }
+
+            var queryParameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(parameters ?? "");
 
             var result = await _queryManager.ExecuteQueryAsync(query, queryParameters);
 

--- a/src/OrchardCore.Modules/Orchard.Queries/Drivers/QueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Drivers/QueryDisplayDriver.cs
@@ -10,9 +10,9 @@ namespace Orchard.Queries.Drivers
 {
     public class QueryDisplayDriver : DisplayDriver<Query>
     {
-        private readonly StringLocalizer<QueryDisplayDriver> S;
+        private readonly IStringLocalizer<QueryDisplayDriver> S;
 
-        public QueryDisplayDriver(StringLocalizer<QueryDisplayDriver> stringLocalizer)
+        public QueryDisplayDriver(IStringLocalizer<QueryDisplayDriver> stringLocalizer)
         {
             S = stringLocalizer;
         }

--- a/src/OrchardCore.Modules/Orchard.Queries/Drivers/QueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Drivers/QueryDisplayDriver.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Orchard.DisplayManagement.Handlers;
 using Orchard.DisplayManagement.ModelBinding;
 using Orchard.DisplayManagement.Views;
@@ -8,6 +10,13 @@ namespace Orchard.Queries.Drivers
 {
     public class QueryDisplayDriver : DisplayDriver<Query>
     {
+        private readonly StringLocalizer<QueryDisplayDriver> S;
+
+        public QueryDisplayDriver(StringLocalizer<QueryDisplayDriver> stringLocalizer)
+        {
+            S = stringLocalizer;
+        }
+
         public override IDisplayResult Display(Query query, IUpdateModel updater)
         {
             return Combine(
@@ -52,7 +61,10 @@ namespace Orchard.Queries.Drivers
         {
             await updater.TryUpdateModelAsync(model, Prefix, m => m.Name, m => m.Source);
 
-            // TODO: Validate name is unique and not empty
+            if (String.IsNullOrEmpty(model.Name))
+            {
+                updater.ModelState.AddModelError(nameof(model.Name), S["Name is required"]);
+            }
 
             return await EditAsync(model, updater);
         }

--- a/src/OrchardCore.Modules/Orchard.Queries/Module.txt
+++ b/src/OrchardCore.Modules/Orchard.Queries/Module.txt
@@ -4,5 +4,13 @@ Author: The Orchard Team
 Website: http://orchardproject.net
 Version: 2.0.x
 OrchardVersion: 2.0.x
-Description: Provides querying capabilities.
-Category: Content
+Features: 
+    Orchard.Queries:
+        Name: Queries
+        Description: Provides querying capabilities.
+        Category: Content Management
+    Orchard.Queries.Sql:
+        Name: SQL Queries
+        Description: Introduces a way to create custom Queries in pure SQL.
+        Category: Content Management
+        Dependencies: Orchard.Queries

--- a/src/OrchardCore.Modules/Orchard.Queries/Orchard.Queries.csproj
+++ b/src/OrchardCore.Modules/Orchard.Queries/Orchard.Queries.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Irony" Version="1.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
   </ItemGroup>
 
@@ -35,7 +36,13 @@
     <None Update="Views\Admin\Index.cshtml">
       <PackagePath>assets\$(PackageId)\</PackagePath>
     </None>
+    <None Update="Views\SqlQuery.Edit.cshtml">
+      <PackagePath>assets\$(PackageId)\</PackagePath>
+    </None>
     <None Update="Views\Query - Copy.Summary.cshtml">
+      <PackagePath>assets\$(PackageId)\</PackagePath>
+    </None>
+    <None Update="Views\Query-Sql.Link.cshtml">
       <PackagePath>assets\$(PackageId)\</PackagePath>
     </None>
     <None Update="Views\_ViewImports.cshtml">

--- a/src/OrchardCore.Modules/Orchard.Queries/README.md
+++ b/src/OrchardCore.Modules/Orchard.Queries/README.md
@@ -65,3 +65,20 @@ Verbs: **POST** and **GET**
 | --------- | ---- |------------ |
 | `name` | `myQuery` | The name of the query to execute |
 | `parameters` | `{ size: 3}` | A Json object representing the parameters of the query |
+
+# SQL Queries (Orchard.Queries.Sql)
+
+This feature provide a new type of query targeting the SQL database.
+
+### Queries recipe step
+
+Here is an example for creating a SQL query from a Queries recipe step:
+
+```json
+{
+    "Source": "Sql",
+    "Name": "ContentItems",
+    "Template": "select * from ContentItemIndex", // json encoded query template
+    "ReturnDocuments": false
+}
+```

--- a/src/OrchardCore.Modules/Orchard.Queries/Recipes/QueryStep.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Recipes/QueryStep.cs
@@ -28,11 +28,11 @@ namespace Orchard.Queries.Recipes
             _logger = logger;
         }
 
-        public Task ExecuteAsync(RecipeExecutionContext context)
+        public async Task ExecuteAsync(RecipeExecutionContext context)
         {
             if (!String.Equals(context.Name, "Queries", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.CompletedTask;
+                return;
             }
 
             var model = context.Step.ToObject<QueryStepModel>();
@@ -48,10 +48,8 @@ namespace Orchard.Queries.Recipes
                 }
 
                 var query = token.ToObject(sample.GetType()) as Query;
-                _queryManager.SaveQueryAsync(query);
+                await _queryManager.SaveQueryAsync(query);
             }
-
-            return Task.CompletedTask;  
         }
     }
 

--- a/src/OrchardCore.Modules/Orchard.Queries/Services/QueryManager.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Services/QueryManager.cs
@@ -36,7 +36,7 @@ namespace Orchard.Queries.Services
 
             // Load the currently saved object otherwise it would create a new document
             // as the new session is not tracking the cached object.
-            // TODO: Solve by having an Import method in Session
+            // TODO: Solve by having an Import method in Session or an Id on the document
 
             var existing = await _session.Query<QueriesDocument>().FirstOrDefaultAsync();
 
@@ -55,7 +55,14 @@ namespace Orchard.Queries.Services
 
         public async Task<Query> GetQueryAsync(string name)
         {
-            return (await GetDocumentAsync()).Queries[name];
+            var document = await GetDocumentAsync();
+
+            if(document.Queries.TryGetValue(name, out var query))
+            {
+                return query;
+            }
+
+            return null;
         }
 
         public async Task<IEnumerable<Query>> ListQueriesAsync()

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/AdminMenu.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/AdminMenu.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Localization;
+using Orchard.Environment.Navigation;
+using System;
+
+namespace Orchard.Queries.Sql
+{
+    public class AdminMenu : INavigationProvider
+    {
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
+        {
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; set; }
+
+        public void BuildNavigation(string name, NavigationBuilder builder)
+        {
+            if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            builder
+                .Add(T["Design"], "10", design => design
+                    .AddClass("menu-design").Id("design")
+                    .Add(T["Site"], "10", site => site
+                        .Add(T["SQL Queries"], "5", queries => queries
+                            .Action("Query", "Admin", new { area = "Orchard.Queries" })
+                            .Permission(Permissions.ManageSqlQueries)
+                            .LocalNav())));
+
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
@@ -67,7 +67,7 @@ namespace Orchard.Queries.Sql.Controllers
             var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(model.Parameters);
             var tokenizedQuery = _tokenizer.Tokenize(model.DecodedQuery, parameters);
 
-            if (SqlParser.TryParse(tokenizedQuery, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
+            if (SqlParser.TryParse(tokenizedQuery, dialect, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
             {
                 model.RawSql = rawQuery;
                 model.RawParameters = JsonConvert.SerializeObject(rawParameters);

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
@@ -37,7 +37,7 @@ namespace Orchard.Queries.Sql.Controllers
         public Task<IActionResult> Query(string query)
         {
             query = String.IsNullOrWhiteSpace(query) ? "" : System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(query));
-            return Query(new AdminQueryViewModel { DecodedQuery = query }, _tokenizer);
+            return Query(new AdminQueryViewModel { DecodedQuery = query });
         }
 
         [HttpPost]

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Modules;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using Newtonsoft.Json;
+using Orchard.Queries.Sql.ViewModels;
+using Orchard.Tokens.Services;
+using YesSql;
+
+namespace Orchard.Queries.Sql.Controllers
+{
+    [Feature("Orchard.Queries.Sql")]
+    public class AdminController : Controller
+    {
+        private readonly IAuthorizationService _authorizationService;
+        private readonly IStore _store;
+        private readonly ITokenizer _tokenizer;
+        private readonly IStringLocalizer<AdminController> _stringLocalizer;
+
+        public AdminController(
+            IAuthorizationService authorizationService, 
+            IStore store, 
+            ITokenizer tokenizer,
+            IStringLocalizer<AdminController> stringLocalizer)
+        {
+            _authorizationService = authorizationService;
+            _store = store;
+            _tokenizer = tokenizer;
+            _stringLocalizer = stringLocalizer;
+        }
+
+        public Task<IActionResult> Query(string query, [FromServices] ITokenizer tokenizer)
+        {
+            query = String.IsNullOrWhiteSpace(query) ? "" : System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(query));
+            return Query(new AdminQueryViewModel { DecodedQuery = query }, tokenizer);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Query(AdminQueryViewModel model, [FromServices] ITokenizer tokenizer)
+        {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageSqlQueries))
+            {
+                return Unauthorized();
+            }
+
+            if (String.IsNullOrWhiteSpace(model.DecodedQuery))
+            {
+                return View(model);
+            }
+
+            if (String.IsNullOrEmpty(model.Parameters))
+            {
+                model.Parameters = "{ }";
+            }
+            
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var connection = _store.Configuration.ConnectionFactory.CreateConnection();
+            var dialect = SqlDialectFactory.For(connection);
+
+            var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(model.Parameters);
+            var tokenizedQuery = _tokenizer.Tokenize(model.DecodedQuery, parameters);
+
+            if (SqlParser.TryParse(tokenizedQuery, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
+            {
+                model.RawSql = rawQuery;
+                model.RawParameters = JsonConvert.SerializeObject(rawParameters);
+
+                try
+                {
+                    using (connection)
+                    {
+                        connection.Open();
+                        model.Documents = await connection.QueryAsync(rawQuery, rawParameters);
+                    }
+                }
+                catch(Exception e)
+                {
+                    ModelState.AddModelError("", _stringLocalizer["An error occured while executing the SQL query: {0}", e.Message]);
+                }
+            }
+            else
+            {
+                foreach (var message in messages)
+                {
+                    ModelState.AddModelError("", message);
+                }
+            }
+
+            model.Elapsed = stopwatch.Elapsed;
+
+            return View(model);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Controllers/AdminController.cs
@@ -34,14 +34,14 @@ namespace Orchard.Queries.Sql.Controllers
             _stringLocalizer = stringLocalizer;
         }
 
-        public Task<IActionResult> Query(string query, [FromServices] ITokenizer tokenizer)
+        public Task<IActionResult> Query(string query)
         {
             query = String.IsNullOrWhiteSpace(query) ? "" : System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(query));
-            return Query(new AdminQueryViewModel { DecodedQuery = query }, tokenizer);
+            return Query(new AdminQueryViewModel { DecodedQuery = query }, _tokenizer);
         }
 
         [HttpPost]
-        public async Task<IActionResult> Query(AdminQueryViewModel model, [FromServices] ITokenizer tokenizer)
+        public async Task<IActionResult> Query(AdminQueryViewModel model)
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageSqlQueries))
             {

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
@@ -39,7 +39,7 @@ namespace Orchard.Queries.Sql.Drivers
             return Shape<SqlQueryViewModel>("SqlQuery_Edit", model =>
             {
                 model.Query = query.Template;
-                model.ReturnContentItems = query.ReturnContentItems;
+                model.ReturnDocuments = query.ReturnDocuments;
 
                 // Extract query from the query string if we come from the main query editor
                 if (string.IsNullOrEmpty(query.Template))
@@ -53,10 +53,10 @@ namespace Orchard.Queries.Sql.Drivers
         public override async Task<IDisplayResult> UpdateAsync(SqlQuery model, IUpdateModel updater)
         {
             var viewModel = new SqlQueryViewModel();
-            if (await updater.TryUpdateModelAsync(viewModel, Prefix, m => m.Query, m => m.ReturnContentItems))
+            if (await updater.TryUpdateModelAsync(viewModel, Prefix, m => m.Query, m => m.ReturnDocuments))
             {
                 model.Template = viewModel.Query;
-                model.ReturnContentItems = viewModel.ReturnContentItems;
+                model.ReturnDocuments = viewModel.ReturnDocuments;
             }
 
             return Edit(model);

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
@@ -40,6 +40,13 @@ namespace Orchard.Queries.Sql.Drivers
             {
                 model.Query = query.Template;
                 model.ReturnContentItems = query.ReturnContentItems;
+
+                // Extract query from the query string if we come from the main query editor
+                if (string.IsNullOrEmpty(query.Template))
+                {
+                    updater.TryUpdateModelAsync(model, "", m => m.Query);
+                }
+
             }).Location("Content:5");
         }
 

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
@@ -1,0 +1,58 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Orchard.DisplayManagement.Handlers;
+using Orchard.DisplayManagement.ModelBinding;
+using Orchard.DisplayManagement.Views;
+using Orchard.Queries.Sql.ViewModels;
+
+namespace Orchard.Queries.Sql.Drivers
+{
+    public class SqlQueryDisplayDriver : DisplayDriver<Query, SqlQuery>
+    {
+        private IStringLocalizer _stringLocalizer;
+
+        public SqlQueryDisplayDriver(IStringLocalizer<SqlQueryDisplayDriver> stringLocalizer)
+        {
+            _stringLocalizer = stringLocalizer;
+        }
+
+        public override IDisplayResult Display(SqlQuery query, IUpdateModel updater)
+        {
+            return Combine(
+                Shape("SqlQuery_SummaryAdmin", model =>
+                {
+                    model.Query = query;
+
+                    return Task.CompletedTask;
+                }).Location("Content:5"),
+                Shape("SqlQuery_Buttons_SummaryAdmin", model =>
+                {
+                    model.Query = query;
+
+                    return Task.CompletedTask;
+                }).Location("Actions:2")
+            );
+        }
+
+        public override IDisplayResult Edit(SqlQuery query, IUpdateModel updater)
+        {
+            return Shape<SqlQueryViewModel>("SqlQuery_Edit", model =>
+            {
+                model.Query = query.Template;
+                model.ReturnContentItems = query.ReturnContentItems;
+            }).Location("Content:5");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(SqlQuery model, IUpdateModel updater)
+        {
+            var viewModel = new SqlQueryViewModel();
+            if (await updater.TryUpdateModelAsync(viewModel, Prefix, m => m.Query, m => m.ReturnContentItems))
+            {
+                model.Template = viewModel.Query;
+                model.ReturnContentItems = viewModel.ReturnContentItems;
+            }
+
+            return Edit(model);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Permissions.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Permissions.cs
@@ -1,19 +1,17 @@
 using Orchard.Security.Permissions;
 using System.Collections.Generic;
 
-namespace Orchard.Lucene
+namespace Orchard.Queries.Sql
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageIndexes = new Permission("ManageIndexes", "Manage Indexes");
-        public static readonly Permission QueryLuceneApi = new Permission("QueryLuceneApi", "Query Lucene Api", new[] { ManageIndexes });
+        public static readonly Permission ManageSqlQueries = new Permission("ManageSqlQueries", "Manage SQL Queries");
 
         public IEnumerable<Permission> GetPermissions()
         {
             return new[] 
             {
-                ManageIndexes,
-                QueryLuceneApi
+                ManageSqlQueries
             };
         }
 
@@ -24,12 +22,12 @@ namespace Orchard.Lucene
                 new PermissionStereotype
                 {
                     Name = "Administrator",
-                    Permissions = new[] { ManageIndexes }
+                    Permissions = new[] { ManageSqlQueries }
                 },
                 new PermissionStereotype
                 {
                     Name = "Editor",
-                    Permissions = new[] { QueryLuceneApi }
+                    Permissions = new[] { ManageSqlQueries }
                 }
             };
         }

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
@@ -52,9 +52,6 @@ namespace Orchard.Queries.Sql
             var columnSource = new NonTerminal("columnSource");
             var asOpt = new NonTerminal("asOpt");
             var aliasOpt = new NonTerminal("aliasOpt");
-            var aggregate = new NonTerminal("aggregate");
-            var aggregateArg = new NonTerminal("aggregateArg");
-            var aggregateName = new NonTerminal("aggregateName");
             var tuple = new NonTerminal("tuple");
             var joinChainOpt = new NonTerminal("joinChainOpt");
             var joinKindOpt = new NonTerminal("joinKindOpt");
@@ -88,7 +85,7 @@ namespace Orchard.Queries.Sql
             aliasOpt.Rule = Empty | asOpt + Id;
             asOpt.Rule = Empty | AS;
 
-            idlist.Rule = MakePlusRule(idlist, comma, Id);
+            idlist.Rule = MakePlusRule(idlist, comma, columnSource);
 
             aliaslist.Rule = MakePlusRule(aliaslist, comma, aliasItem);
             aliasItem.Rule = Id + aliasOpt;
@@ -106,10 +103,7 @@ namespace Orchard.Queries.Sql
             columnItemList.Rule = MakePlusRule(columnItemList, comma, columnItem);
             columnItem.Rule = columnSource + aliasOpt;
 
-            columnSource.Rule = aggregate | Id;
-            aggregate.Rule = aggregateName + "(" + aggregateArg + ")";
-            aggregateArg.Rule = expression | "*";
-            aggregateName.Rule = COUNT | "Avg" | "Min" | "Max" | "StDev" | "StDevP" | "Sum" | "Var" | "VarP";
+            columnSource.Rule = funCall | Id;
             fromClauseOpt.Rule = Empty | FROM + aliaslist + joinChainOpt;
             joinChainOpt.Rule = Empty | joinKindOpt + JOIN + aliaslist + ON + Id + "=" + Id;
             joinKindOpt.Rule = Empty | "INNER" | "LEFT" | "RIGHT";
@@ -136,7 +130,7 @@ namespace Orchard.Queries.Sql
             notOpt.Rule = Empty | NOT;
             //funCall covers some psedo-operators and special forms like ANY(...), SOME(...), ALL(...), EXISTS(...), IN(...)
             funCall.Rule = Id + "(" + functionArguments + ")";
-            functionArguments.Rule = selectStatement | expressionList;
+            functionArguments.Rule = selectStatement | expressionList | "*";
             inStatement.Rule = expression + "IN" + "(" + expressionList + ")";
 
             //Operators
@@ -156,8 +150,6 @@ namespace Orchard.Queries.Sql
             // in conflict resolution when binOp node is sitting on the stack
             base.MarkTransient(statement, term, asOpt, aliasOpt, statementLine, expression, unOp, tuple);
             binOp.SetFlag(TermFlags.InheritPrecedence);
-
-        }//constructor
-
-    }//class
-}//namespace
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
@@ -81,8 +81,7 @@ namespace Orchard.Queries.Sql
             optionalSemicolon.Rule = Empty | ";";
             statementList.Rule = MakePlusRule(statementList, statementLine);
 
-            statement.Rule = selectStatement
-                      | "GO";
+            statement.Rule = selectStatement;
 
             Id.Rule = MakePlusRule(Id, dot, Id_simple);
 

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlGrammar.cs
@@ -1,0 +1,164 @@
+using Irony.Parsing;
+
+namespace Orchard.Queries.Sql
+{
+    public class SqlGrammar : Grammar
+    {
+        public SqlGrammar() : base(false)
+        {
+            var comment = new CommentTerminal("comment", "/*", "*/");
+            var lineComment = new CommentTerminal("line_comment", "--", "\n", "\r\n");
+            NonGrammarTerminals.Add(comment);
+            NonGrammarTerminals.Add(lineComment);
+            var number = new NumberLiteral("number");
+            var string_literal = new StringLiteral("string", "'", StringOptions.AllowsDoubledQuote);
+            var Id_simple = TerminalFactory.CreateSqlExtIdentifier(this, "id_simple"); //covers normal identifiers (abc) and quoted id's ([abc d], "abc d")
+            var comma = ToTerm(",");
+            var dot = ToTerm(".");
+            var CREATE = ToTerm("CREATE");
+            var NULL = ToTerm("NULL");
+            var NOT = ToTerm("NOT");
+            var ON = ToTerm("ON");
+            var SELECT = ToTerm("SELECT");
+            var FROM = ToTerm("FROM");
+            var AS = ToTerm("AS");
+            var COUNT = ToTerm("COUNT");
+            var JOIN = ToTerm("JOIN");
+            var BY = ToTerm("BY");
+            var TRUE = ToTerm("TRUE");
+            var FALSE = ToTerm("FALSE");
+
+            //Non-terminals
+            var Id = new NonTerminal("Id");
+            var statement = new NonTerminal("stmt");
+            var selectStatement = new NonTerminal("selectStatement");
+            var idlist = new NonTerminal("idlist");
+            var aliaslist = new NonTerminal("aliaslist");
+            var aliasItem = new NonTerminal("aliasItem");
+            var orderList = new NonTerminal("orderList");
+            var orderMember = new NonTerminal("orderMember");
+            var orderDirOptional = new NonTerminal("orderDirOpt");
+            var whereClauseOptional = new NonTerminal("whereClauseOpt");
+            var expression = new NonTerminal("expression");
+            var expressionList = new NonTerminal("exprList");
+            var optionalSelectRestriction = new NonTerminal("optionalSelectRestriction");
+            var selectorList = new NonTerminal("selList");
+            var fromClauseOpt = new NonTerminal("fromClauseOpt");
+            var groupClauseOpt = new NonTerminal("groupClauseOpt");
+            var havingClauseOpt = new NonTerminal("havingClauseOpt");
+            var orderClauseOpt = new NonTerminal("orderClauseOpt");
+            var columnItemList = new NonTerminal("columnItemList");
+            var columnItem = new NonTerminal("columnItem");
+            var columnSource = new NonTerminal("columnSource");
+            var asOpt = new NonTerminal("asOpt");
+            var aliasOpt = new NonTerminal("aliasOpt");
+            var aggregate = new NonTerminal("aggregate");
+            var aggregateArg = new NonTerminal("aggregateArg");
+            var aggregateName = new NonTerminal("aggregateName");
+            var tuple = new NonTerminal("tuple");
+            var joinChainOpt = new NonTerminal("joinChainOpt");
+            var joinKindOpt = new NonTerminal("joinKindOpt");
+            var term = new NonTerminal("term");
+            var unExpr = new NonTerminal("unExpr");
+            var unOp = new NonTerminal("unOp");
+            var binExpr = new NonTerminal("binExpr");
+            var binOp = new NonTerminal("binOp");
+            var betweenExpr = new NonTerminal("betweenExpr");
+            var inExpr = new NonTerminal("inExpr");
+            var parSelectStatement = new NonTerminal("parSelectStmt");
+            var notOpt = new NonTerminal("notOpt");
+            var funCall = new NonTerminal("funCall");
+            var statementLine = new NonTerminal("stmtLine");
+            var optionalSemicolon = new NonTerminal("semiOpt");
+            var statementList = new NonTerminal("stmtList");
+            var functionArguments = new NonTerminal("funArgs");
+            var inStatement = new NonTerminal("inStmt");
+            var boolean = new NonTerminal("boolean");
+
+            //BNF Rules
+            this.Root = statementList;
+            statementLine.Rule = statement + optionalSemicolon;
+            optionalSemicolon.Rule = Empty | ";";
+            statementList.Rule = MakePlusRule(statementList, statementLine);
+
+            statement.Rule = selectStatement
+                      | "GO";
+
+            Id.Rule = MakePlusRule(Id, dot, Id_simple);
+
+            aliasOpt.Rule = Empty | asOpt + Id;
+            asOpt.Rule = Empty | AS;
+
+            idlist.Rule = MakePlusRule(idlist, comma, Id);
+
+            aliaslist.Rule = MakePlusRule(aliaslist, comma, aliasItem);
+            aliasItem.Rule = Id + aliasOpt;
+
+            //Create Index
+            orderList.Rule = MakePlusRule(orderList, comma, orderMember);
+            orderMember.Rule = Id + orderDirOptional;
+            orderDirOptional.Rule = Empty | "ASC" | "DESC";
+
+            //Select stmt
+            selectStatement.Rule = SELECT + optionalSelectRestriction + selectorList + fromClauseOpt + whereClauseOptional +
+                              groupClauseOpt + havingClauseOpt + orderClauseOpt;
+            optionalSelectRestriction.Rule = Empty | "ALL" | "DISTINCT";
+            selectorList.Rule = columnItemList | "*";
+            columnItemList.Rule = MakePlusRule(columnItemList, comma, columnItem);
+            columnItem.Rule = columnSource + aliasOpt;
+
+            columnSource.Rule = aggregate | Id;
+            aggregate.Rule = aggregateName + "(" + aggregateArg + ")";
+            aggregateArg.Rule = expression | "*";
+            aggregateName.Rule = COUNT | "Avg" | "Min" | "Max" | "StDev" | "StDevP" | "Sum" | "Var" | "VarP";
+            fromClauseOpt.Rule = Empty | FROM + aliaslist + joinChainOpt;
+            joinChainOpt.Rule = Empty | joinKindOpt + JOIN + aliaslist + ON + Id + "=" + Id;
+            joinKindOpt.Rule = Empty | "INNER" | "LEFT" | "RIGHT";
+            whereClauseOptional.Rule = Empty | "WHERE" + expression;
+            groupClauseOpt.Rule = Empty | "GROUP" + BY + idlist;
+            havingClauseOpt.Rule = Empty | "HAVING" + expression;
+            orderClauseOpt.Rule = Empty | "ORDER" + BY + orderList;
+
+            //Expression
+            expressionList.Rule = MakePlusRule(expressionList, comma, expression);
+            expression.Rule = term | unExpr | binExpr | betweenExpr;
+            term.Rule = Id | boolean | string_literal | number | funCall | tuple | parSelectStatement | inStatement;
+            boolean.Rule = TRUE | FALSE;
+            tuple.Rule = "(" + expressionList + ")";
+            parSelectStatement.Rule = "(" + selectStatement + ")";
+            unExpr.Rule = unOp + term;
+            unOp.Rule = NOT | "+" | "-" | "~";
+            binExpr.Rule = expression + binOp + expression;
+            binOp.Rule = ToTerm("+") | "-" | "*" | "/" | "%" //arithmetic
+                       | "&" | "|" | "^"                     //bit
+                       | "=" | ">" | "<" | ">=" | "<=" | "<>" | "!=" | "!<" | "!>"
+                       | "AND" | "OR" | "LIKE" | NOT + "LIKE" | "IN" | NOT + "IN";
+            betweenExpr.Rule = expression + notOpt + "BETWEEN" + expression + "AND" + expression;
+            notOpt.Rule = Empty | NOT;
+            //funCall covers some psedo-operators and special forms like ANY(...), SOME(...), ALL(...), EXISTS(...), IN(...)
+            funCall.Rule = Id + "(" + functionArguments + ")";
+            functionArguments.Rule = selectStatement | expressionList;
+            inStatement.Rule = expression + "IN" + "(" + expressionList + ")";
+
+            //Operators
+            RegisterOperators(10, "*", "/", "%");
+            RegisterOperators(9, "+", "-");
+            RegisterOperators(8, "=", ">", "<", ">=", "<=", "<>", "!=", "!<", "!>", "LIKE", "IN");
+            RegisterOperators(7, "^", "&", "|");
+            RegisterOperators(6, NOT);
+            RegisterOperators(5, "AND");
+            RegisterOperators(4, "OR");
+
+            MarkPunctuation(",", "(", ")");
+            MarkPunctuation(asOpt, optionalSemicolon);
+            //Note: we cannot declare binOp as transient because it includes operators "NOT LIKE", "NOT IN" consisting of two tokens. 
+            // Transient non-terminals cannot have more than one non-punctuation child nodes.
+            // Instead, we set flag InheritPrecedence on binOp , so that it inherits precedence value from it's children, and this precedence is used
+            // in conflict resolution when binOp node is sitting on the stack
+            base.MarkTransient(statement, term, asOpt, aliasOpt, statementLine, expression, unOp, tuple);
+            binOp.SetFlag(TermFlags.InheritPrecedence);
+
+        }//constructor
+
+    }//class
+}//namespace

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlParser.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlParser.cs
@@ -296,7 +296,7 @@ namespace Orchard.Queries.Sql
                 }
             }
 
-            _builder.Append(_dialect.RenderMethod(funcName.ToLowerInvariant(), arguments.ToArray()));
+            _builder.Append(_dialect.RenderMethod(funcName, arguments.ToArray()));
         }
 
         private void EvaluateExpressionList(ParseTreeNode expressionList)

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlParser.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlParser.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Irony.Parsing;
+
+namespace Orchard.Queries.Sql
+{
+    public class SqlParser
+    {
+        private StringBuilder _builder;
+        private Dictionary<string, object> _parameters;
+        private string _tablePrefix;
+        private HashSet<string> _aliases;
+        private ParseTree _tree;
+        private static LanguageData language = new LanguageData(new SqlGrammar());
+
+        private SqlParser(ParseTree tree, string tablePrefix)
+        {
+            _tree = tree;
+            _tablePrefix = tablePrefix;
+            _parameters = new Dictionary<string, object>();
+            _builder = new StringBuilder(tree.SourceText.Length);
+        }
+
+        public static bool TryParse(string sql, string tablePrefix, out string query, out Dictionary<string, object> parameters, out IEnumerable<string> messages)
+        {
+            try
+            {
+                var tree = new Irony.Parsing.Parser(language).Parse(sql);
+
+                if (tree.HasErrors())
+                {
+                    query = null;
+                    parameters = null;
+
+                    messages = tree
+                        .ParserMessages
+                        .Select(x => $"{x.Message} ({x.Location.Line}:{x.Location.Column})")
+                        .ToArray();
+
+                    return false;
+                }
+
+                var sqlParser = new SqlParser(tree, tablePrefix);
+                sqlParser.Evaluate();
+
+                query = sqlParser._builder.ToString();
+                parameters = sqlParser._parameters;
+                messages = Array.Empty<string>();
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                query = null;
+                parameters = null;
+                messages = new string[] { "Unexpected error: " + e.Message };
+            }
+
+            return false;
+        }
+
+        private void Evaluate()
+        {
+            PopulateAliases(_tree);
+            var statementList = _tree.Root;
+
+            foreach (var selectStatement in statementList.ChildNodes)
+            {
+                EvaluateSelectStatement(selectStatement);
+            }
+        }
+
+        private void PopulateAliases(ParseTree tree)
+        {
+            // In order to determine if an Id is a table name or an alias, we 
+            // analyze every Alias and store the value.
+
+            _aliases = new HashSet<string>();
+
+            for (var i = 0; i < tree.Tokens.Count; i++)
+            {
+                if (tree.Tokens[i].Terminal.Name == "AS")
+                {
+                    _aliases.Add(tree.Tokens[i + 1].ValueString);
+                }
+            }
+        }
+
+        private void EvaluateSelectStatement(ParseTreeNode selectStatement)
+        {
+            _builder.Append("SELECT");
+            EvaluateSelectRestriction(selectStatement.ChildNodes[1]);
+            EvaluateSelectorList(selectStatement.ChildNodes[2]);
+            EvaluateFromClause(selectStatement.ChildNodes[3]);
+            EvaluateWhereClause(selectStatement.ChildNodes[4]);
+            EvaluateGroupClause(selectStatement.ChildNodes[5]);
+            EvaluateHavingClause(selectStatement.ChildNodes[6]);
+            EvaluateOrderClause(selectStatement.ChildNodes[7]);
+            _builder.Append(";");
+        }
+
+        private void EvaluateOrderClause(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count == 0)
+            {
+                return;
+            }
+
+            _builder.AppendLine().Append("ORDER BY");
+
+            var idList = parseTreeNode.ChildNodes[2];
+
+            for (var i = 0; i < idList.ChildNodes.Count; i++)
+            {
+                var id = idList.ChildNodes[i].ChildNodes[0];
+
+                if (i > 0)
+                {
+                    _builder.Append(",");
+                }
+
+                EvaluateId(id, true);
+
+                if (idList.ChildNodes[i].ChildNodes[1].ChildNodes.Count > 0)
+                {
+                    _builder.Append(" ").Append(idList.ChildNodes[i].ChildNodes[1].ChildNodes[0].Term.Name);
+                }
+            }
+        }
+
+        private void EvaluateHavingClause(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count == 0)
+            {
+                return;
+            }
+
+            _builder.AppendLine().Append("HAVING");
+            EvaluateExpression(parseTreeNode.ChildNodes[1]);
+        }
+
+        private void EvaluateGroupClause(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count == 0)
+            {
+                return;
+            }
+
+            _builder.AppendLine().Append("GROUP BY");
+
+            var idList = parseTreeNode.ChildNodes[2];
+
+            for (var i = 0; i < idList.ChildNodes.Count; i++)
+            {
+                var id = idList.ChildNodes[i];
+
+                if (i > 0)
+                {
+                    _builder.Append(",");
+                }
+
+                EvaluateId(id, true);
+            }
+        }
+
+        private void EvaluateWhereClause(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count == 0)
+            {
+                // EMPTY
+                return;
+            }
+
+            _builder.AppendLine().Append("WHERE");
+
+            EvaluateExpression(parseTreeNode.ChildNodes[1]);
+        }
+
+        private void EvaluateExpression(ParseTreeNode parseTreeNode)
+        {
+            switch (parseTreeNode.Term.Name)
+            {
+                case "unExpr":
+                    _builder.Append(" ").Append(parseTreeNode.ChildNodes[0].Term.Name);
+                    EvaluateTerm(parseTreeNode.ChildNodes[1]);
+                    break;
+                case "binExpr":
+                    EvaluateExpression(parseTreeNode.ChildNodes[0]);
+                    _builder.Append(" ").Append(parseTreeNode.ChildNodes[1].ChildNodes[0].Term.Name);
+                    EvaluateExpression(parseTreeNode.ChildNodes[2]);
+                    break;
+                case "betweenExpr":
+                    EvaluateExpression(parseTreeNode.ChildNodes[0]);
+                    if (parseTreeNode.ChildNodes[1].ChildNodes.Count > 0)
+                    {
+                        _builder.Append(" NOT");
+                    }
+                    _builder.Append(" BETWEEN");
+                    EvaluateExpression(parseTreeNode.ChildNodes[3]);
+                    _builder.Append(" AND");
+                    EvaluateExpression(parseTreeNode.ChildNodes[5]);
+                    break;
+                default:
+                    EvaluateTerm(parseTreeNode);
+                    break;
+            }
+
+            void EvaluateTerm(ParseTreeNode term)
+            {
+                switch (term.Term.Name)
+                {
+                    case "Id":
+                        EvaluateTermId(term);
+                        break;
+                    case "boolean":
+                        _builder.Append(" ").Append(AddParameter(term.ChildNodes[0].Term.Name == "TRUE"));
+                        break;
+                    case "string":
+                        _builder.Append(" ").Append(AddParameter(term.Token.ValueString));
+                        break;
+                    case "number":
+                        _builder.Append(" ").Append(AddParameter(term.Token.Value));
+                        break;
+                    case "funCall":
+                        EvaluateId(term.ChildNodes[0], false);
+                        _builder.Append("(");
+                        if (term.ChildNodes[1].ChildNodes[0].Term.Name == "selectStatement")
+                        {
+                            // selectStatement
+                            EvaluateSelectStatement(term.ChildNodes[1].ChildNodes[0]);
+                        }
+                        else
+                        {
+                            // expressionList
+                            EvaluateExpressionList(term.ChildNodes[1].ChildNodes[0]);
+                        }
+                        _builder.Append(")");
+                        break;
+                    case "tuple":
+                        _builder.Append(" (");
+                        EvaluateExpressionList(term.ChildNodes[1]);
+                        _builder.Append(")");
+                        break;
+                    case "parSelectStmt":
+                        _builder.Append(" (");
+                        EvaluateSelectStatement(term.ChildNodes[1]);
+                        _builder.Append(")");
+                        break;
+                    case "inStatement":
+                        EvaluateExpression(term.ChildNodes[0]);
+                        _builder.Append(" IN (");
+                        EvaluateExpressionList(term.ChildNodes[2]);
+                        _builder.Append(")");
+                        break;
+                }
+
+                void EvaluateExpressionList(ParseTreeNode expressionList)
+                {
+                    for (var i = 0; i < expressionList.ChildNodes.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            _builder.Append(",");
+                        }
+
+                        EvaluateExpression(expressionList.ChildNodes[i]);
+                    }
+                }
+            }
+        }
+
+        private void EvaluateFromClause(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count == 0)
+            {
+                // EMPTY
+                return;
+            }
+
+            var aliasList = parseTreeNode.ChildNodes[1];
+
+            if (aliasList.ChildNodes.Count > 0)
+            {
+                _builder.AppendLine().Append("FROM");
+            }
+
+            EvaluateAliasList(aliasList);
+
+            var joins = parseTreeNode.ChildNodes[2];
+
+            if (joins.ChildNodes.Count != 0)
+            {
+                _builder.AppendLine();
+
+                var jointKindOpt = joins.ChildNodes[0];
+
+                if (jointKindOpt.ChildNodes.Count > 0)
+                {
+                    _builder.Append(jointKindOpt.ChildNodes[0].Term.Name);
+                }
+
+                _builder.Append(" JOIN");
+
+                EvaluateAliasList(joins.ChildNodes[2]);
+
+                _builder.Append(" ON");
+
+                EvaluateId(joins.ChildNodes[4], true);
+
+                _builder.Append(" =");
+
+                EvaluateId(joins.ChildNodes[6], true);
+            }
+        }
+
+        private void EvaluateAliasList(ParseTreeNode aliasList)
+        {
+            for (var i = 0; i < aliasList.ChildNodes.Count; i++)
+            {
+                var aliasItem = aliasList.ChildNodes[i];
+
+                if (i > 0)
+                {
+                    _builder.Append(",");
+                }
+
+                EvaluateId(aliasItem.ChildNodes[0], true);
+
+                if (aliasItem.ChildNodes.Count > 1)
+                {
+                    EvaluateAliasOptional(aliasItem.ChildNodes[1]);
+                }
+            }
+        }
+
+        private void EvaluateSelectorList(ParseTreeNode parseTreeNode)
+        {
+            var selectorList = parseTreeNode.ChildNodes[0];
+
+            _builder.Append(" ");
+
+            if (selectorList.Term.Name == "*")
+            {
+                _builder.Append("*");
+            }
+            else
+            {
+                // columnItemList
+                for (var i = 0; i < selectorList.ChildNodes.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        _builder.Append(",");
+                    }
+
+                    var columnItem = selectorList.ChildNodes[i];
+
+                    // columnItem
+                    var columnSource = columnItem.ChildNodes[0];
+                    var aggregateOrId = columnSource.ChildNodes[0];
+                    if (aggregateOrId.Term.Name == "Id")
+                    {
+                        EvaluateId(aggregateOrId, true);
+                    }
+                    else
+                    {
+                        _builder.Append($" {aggregateOrId.ChildNodes[0].Token.ValueString} ({aggregateOrId.ChildNodes[1].Token.ValueString})");
+                    }
+
+                    if (columnItem.ChildNodes.Count > 1)
+                    {
+                        // AS
+                        EvaluateAliasOptional(columnItem.ChildNodes[1]);
+                    }
+                }
+            }
+        }
+
+        private void EvaluateId(ParseTreeNode id, bool prefix)
+        {
+            for (var i = 0; i < id.ChildNodes.Count; i++)
+            {
+                if (i == 0)
+                {
+                    _builder.Append(" ");
+                }
+
+                if (prefix && i == 0 && !_aliases.Contains(id.ChildNodes[i].Token.ValueString))
+                {
+                    _builder.Append(_tablePrefix);
+                }
+
+                if (i > 0)
+                {
+                    _builder.Append(".");
+                }
+
+                _builder.Append(id.ChildNodes[i].Token.Value);
+            }
+        }
+
+        private void EvaluateTermId(ParseTreeNode id)
+        {
+            // These ids represent columns but as not aliasable (WHERE clause)
+            for (var i = 0; i < id.ChildNodes.Count; i++)
+            {
+                if (i == 0)
+                {
+                    _builder.Append(" ");
+                }
+
+                if (i == 0 && id.ChildNodes.Count > 1 && !_aliases.Contains(id.ChildNodes[i].Token.ValueString))
+                {
+                    _builder.Append(_tablePrefix);
+                }
+
+                if (i > 0)
+                {
+                    _builder.Append(".");
+                }
+
+                _builder.Append(id.ChildNodes[i].Token.Value);
+            }
+        }
+
+        private void EvaluateAliasOptional(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count > 0)
+            {
+                _builder.Append(" AS ");
+                _builder.Append(parseTreeNode.ChildNodes[0].Token.ValueString);
+            }
+        }
+
+        private void EvaluateSelectRestriction(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode.ChildNodes.Count > 0)
+            {
+                _builder.Append(" ").Append(parseTreeNode.ChildNodes[0].Term.Name);
+            }
+        }
+
+        private string AddParameter(object value)
+        {
+            var parameterName = "@p" + _parameters.Count;
+            _parameters.Add(parameterName, value);
+            return parameterName;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuery.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuery.cs
@@ -1,0 +1,14 @@
+using Orchard.Queries;
+
+namespace Orchard.Queries.Sql
+{
+    public class SqlQuery : Query
+    {
+        public SqlQuery() : base("Sql")
+        {
+        }
+
+        public string Template { get; set; }
+        public bool ReturnContentItems { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuery.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuery.cs
@@ -1,5 +1,3 @@
-using Orchard.Queries;
-
 namespace Orchard.Queries.Sql
 {
     public class SqlQuery : Query
@@ -9,6 +7,6 @@ namespace Orchard.Queries.Sql
         }
 
         public string Template { get; set; }
-        public bool ReturnContentItems { get; set; }
+        public bool ReturnDocuments { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuerySource.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuerySource.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dapper;
+using Orchard.Tokens.Services;
+using YesSql;
+
+namespace Orchard.Queries.Sql
+{
+    public class SqlQuerySource : IQuerySource
+    {
+        private readonly IStore _store;
+        private readonly ITokenizer _tokenizer;
+
+        public SqlQuerySource(
+            IStore store,
+            ITokenizer tokenizer)
+        {
+            _store = store;
+            _tokenizer = tokenizer;
+        }
+
+        public string Name => "Sql";
+
+        public Query Create()
+        {
+            return new SqlQuery();
+        }
+
+        public async Task<object> ExecuteQueryAsync(Query query, IDictionary<string, object> parameters)
+        {
+            var sqlQuery = query as SqlQuery;
+            object result = null;
+
+            var tokenizedQuery = _tokenizer.Tokenize(sqlQuery.Template, parameters);
+
+            var connection = _store.Configuration.ConnectionFactory.CreateConnection();
+            var dialect = SqlDialectFactory.For(connection);
+
+            if (SqlParser.TryParse(sqlQuery.Template, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
+            {
+                using (connection)
+                {
+                    connection.Open();
+                    result = await connection.QueryAsync(rawQuery, rawParameters);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuerySource.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/SqlQuerySource.cs
@@ -36,7 +36,7 @@ namespace Orchard.Queries.Sql
             var connection = _store.Configuration.ConnectionFactory.CreateConnection();
             var dialect = SqlDialectFactory.For(connection);
 
-            if (SqlParser.TryParse(sqlQuery.Template, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
+            if (SqlParser.TryParse(sqlQuery.Template, dialect, _store.Configuration.TablePrefix, out var rawQuery, out var rawParameters, out var messages))
             {
                 using (connection)
                 {

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Startup.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Modules;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Orchard.DisplayManagement.Handlers;
+using Orchard.Environment.Navigation;
+using Orchard.Queries.Sql.Drivers;
+using Orchard.Security.Permissions;
+
+namespace Orchard.Queries.Sql
+{
+    /// <summary>
+    /// These services are registered on the tenant service collection
+    /// </summary>
+    [Feature("Orchard.Queries.Sql")]
+    public class Startup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<IPermissionProvider, Permissions>();
+            services.AddScoped<IDisplayDriver<Query>, SqlQueryDisplayDriver>();
+            services.AddScoped<IQuerySource, SqlQuerySource>();
+            services.AddScoped<INavigationProvider, AdminMenu>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+        }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/Startup.cs
@@ -23,9 +23,5 @@ namespace Orchard.Queries.Sql
             services.AddScoped<IQuerySource, SqlQuerySource>();
             services.AddScoped<INavigationProvider, AdminMenu>();
         }
-
-        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
-        {
-        }
     }
 }

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/AdminQueryViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/AdminQueryViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Orchard.Queries.Sql.ViewModels
+{
+    public class AdminQueryViewModel
+    {
+        public string DecodedQuery { get; set; }
+        public string Parameters { get; set; }
+
+        [BindNever]
+        public string RawSql { get; set; }
+
+        [BindNever]
+        public string RawParameters{ get; set; }
+
+        [BindNever]
+        public TimeSpan Elapsed { get; set; } = TimeSpan.Zero;
+
+        [BindNever]
+        public IEnumerable<dynamic> Documents { get; set; } = Enumerable.Empty<dynamic>();
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/AdminQueryViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/AdminQueryViewModel.cs
@@ -8,7 +8,7 @@ namespace Orchard.Queries.Sql.ViewModels
     public class AdminQueryViewModel
     {
         public string DecodedQuery { get; set; }
-        public string Parameters { get; set; }
+        public string Parameters { get; set; } = "";
 
         [BindNever]
         public string RawSql { get; set; }

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/SqlQueryViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/SqlQueryViewModel.cs
@@ -7,6 +7,6 @@ namespace Orchard.Queries.Sql.ViewModels
         [Required]
         public string Query { get; set; }
 
-        public bool ReturnContentItems { get; set; }
+        public bool ReturnDocuments { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/SqlQueryViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Sql/ViewModels/SqlQueryViewModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Orchard.Queries.Sql.ViewModels
+{
+    public class SqlQueryViewModel
+    {
+        [Required]
+        public string Query { get; set; }
+
+        public bool ReturnContentItems { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/Orchard.Queries/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Routing;
@@ -10,6 +11,7 @@ using Orchard.Queries.Drivers;
 using Orchard.Queries.Recipes;
 using Orchard.Queries.Services;
 using Orchard.Recipes;
+using Orchard.Security.Permissions;
 
 namespace Orchard.Queries
 {
@@ -26,6 +28,7 @@ namespace Orchard.Queries
 
             services.AddScoped<IDisplayDriver<Query>, QueryDisplayDriver>();
             services.AddRecipeExecutionStep<QueryStep>();
+            services.AddScoped<IPermissionProvider, Permissions>();
         }
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/Orchard.Queries/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Queries/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Routing;

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Index.cshtml
@@ -48,7 +48,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <div class="card-columns">
+                <div class="">
                     @if (!Model.QuerySourceNames.Any())
                     {
                         <h3>@T["You need to enable a feature which provides a query source."]</h3>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Index.cshtml
@@ -48,7 +48,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <div class="">
+                <div class="card-columns">
                     @if (!Model.QuerySourceNames.Any())
                     {
                         <h3>@T["You need to enable a feature which provides a query source."]</h3>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
@@ -1,0 +1,93 @@
+@model Orchard.Queries.Sql.ViewModels.AdminQueryViewModel
+@using Orchard.ContentManagement;
+@inject IContentManager ContentManager
+
+@{
+    var matchAllQuery = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(@"SELECT * FROM ContentItemIndex"));
+}
+
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js" depends-on="admin" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/sql/sql.js" at="Foot"></script>
+
+<h1>@RenderTitleSegments(T["SQL Query"])</h1>
+
+<div asp-validation-summary="All" class="text-danger"></div>
+
+<form asp-action="Query" method="post">
+
+    <div class="form-group">
+        <label asp-for="DecodedQuery">@T["Template"]</label>
+        <textarea asp-for="DecodedQuery" rows="12" class="form-control"></textarea>
+        <span class="hint">@T["You can <a href=\"{0}\">click here</a> to query all content items.", Html.Raw(Url.Action("Query", "Admin", new { area = "Orchard.Queries", Query = matchAllQuery }))]</span>
+        <span class="hint">@T["The SQL query uses standard SQL92 syntax and is converted based on the actual database. Table will be prefixed automatically.</a>"]</span>
+    </div>
+
+    <div class="form-group">
+        <label asp-for="Parameters">@T["Parameters"]</label>
+        <textarea asp-for="Parameters" rows="6" class="form-control"></textarea>
+        <span class="hint">@T["An optional Json object containing the parameter values for this query."]</span>
+    </div>
+
+    <div class="form-group">
+        <button type="submit" class="btn btn-primary">@T["Query"]</button>
+    </div>
+</form>
+
+@if (Model.Elapsed != TimeSpan.Zero)
+{
+    <span class="text-muted">@T["Query executed in {0} ms", Model.Elapsed.TotalMilliseconds]</span>
+
+    <div class="form-group">
+        <label asp-for="RawSql">@T["Final SQL Query"]</label>
+        <textarea asp-for="RawSql" rows="12" class="form-control"></textarea>
+        <span class="hint">@T["The query as it will be executed by the SQL database."]</span>
+    </div>
+
+    <div class="form-group">
+        <label asp-for="RawParameters">@T["Final Parameters"]</label>
+        <textarea asp-for="RawParameters" rows="6" class="form-control"></textarea>
+        <span class="hint">@T["The parameters that are sent to the SQL database."]</span>
+    </div>
+}
+
+@if (Model.Documents.Any())
+{
+    
+    @foreach (var document in Model.Documents)
+    {
+        <div>@Json.Serialize(document)</div>
+    }
+
+    @*<table class="table table-striped table-hover table-responsive">
+        <thead>
+            <tr>
+                <th>#</th>
+                @foreach (var field in Model.Documents.First())
+                {
+                <th>@field.Name</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @{ int row = 1; }
+            @foreach (var document in Model.Documents)
+            {
+            <tr>
+                <th scope="row">@(row++)</th>
+                @foreach (var field in document)
+                {
+                    <td>@field.StringValue</td>
+                }
+            </tr>
+            }
+        </tbody>
+    </table>*@
+}
+<script at="Foot">
+    $(function() {
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: "text/x-sql", lineNumbers: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.RawSql)'), { mode: "text/x-sql", lineNumbers: true, readonly: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.RawParameters)'), { mode: "javascript", readonly: true, json: true, lineNumbers: true, viewportMargin: Infinity });
+    });
+</script>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
@@ -14,45 +14,54 @@
 
 <div asp-validation-summary="All" class="text-danger"></div>
 
-<form asp-action="Query" method="post">
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Query" method="post">
 
-    <div class="form-group">
-        <label asp-for="DecodedQuery">@T["Template"]</label>
-        <textarea asp-for="DecodedQuery" rows="12" class="form-control"></textarea>
-        <span class="hint">@T["You can <a href=\"{0}\">click here</a> to query all content items.", Html.Raw(Url.Action("Query", "Admin", new { area = "Orchard.Queries", Query = matchAllQuery }))]</span>
-        <span class="hint">@T["The SQL query uses standard SQL92 syntax and is converted based on the actual database. Table will be prefixed automatically.</a>"]</span>
+            <div class="form-group">
+                <label asp-for="DecodedQuery">@T["Template"]</label>
+                <textarea asp-for="DecodedQuery" rows="12" class="form-control"></textarea>
+                <span class="hint">@T["You can <a href=\"{0}\">click here</a> to query all content items.", Html.Raw(Url.Action("Query", "Admin", new { area = "Orchard.Queries", Query = matchAllQuery }))]</span>
+                <span class="hint">@T["The SQL query uses standard SQL92 syntax and is converted based on the actual database. Table will be prefixed automatically.</a>"]</span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="Parameters">@T["Parameters"]</label>
+                <textarea asp-for="Parameters" rows="1" class="form-control"></textarea>
+                <span class="hint">@T["An optional Json object containing the parameter values for this query."]</span>
+            </div>
+
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">@T["Query"]</button>
+            </div>
+        </form>
     </div>
+    @if (Model.Elapsed != TimeSpan.Zero)
+    {
+        <div class="col-md-6">
+            <div class="form-group">
+                <label asp-for="RawSql">@T["Final SQL Query"]</label>
+                <textarea asp-for="RawSql" rows="12" class="form-control"></textarea>
+                <span class="hint">@T["The query as it will be executed by the SQL database."]</span>
+            </div>
 
-    <div class="form-group">
-        <label asp-for="Parameters">@T["Parameters"]</label>
-        <textarea asp-for="Parameters" rows="1" class="form-control"></textarea>
-        <span class="hint">@T["An optional Json object containing the parameter values for this query."]</span>
-    </div>
+            <div class="form-group">
+                <label asp-for="RawParameters">@T["Final Parameters"]</label>
+                <textarea asp-for="RawParameters" rows="1" class="form-control"></textarea>
+                <span class="hint">@T["The parameters that are sent to the SQL database."]</span>
+            </div>
 
-    <div class="form-group">
-        <button type="submit" class="btn btn-primary">@T["Query"]</button>
-    </div>
-</form>
-
-@if (Model.Elapsed != TimeSpan.Zero)
-{
-    <span class="text-muted">@T["Query executed in {0} ms", Model.Elapsed.TotalMilliseconds]</span>
-
-    <div class="form-group">
-        <label asp-for="RawSql">@T["Final SQL Query"]</label>
-        <textarea asp-for="RawSql" rows="12" class="form-control"></textarea>
-        <span class="hint">@T["The query as it will be executed by the SQL database."]</span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="RawParameters">@T["Final Parameters"]</label>
-        <textarea asp-for="RawParameters" rows="1" class="form-control"></textarea>
-        <span class="hint">@T["The parameters that are sent to the SQL database."]</span>
-    </div>
-}
+            <div class="form-group">
+                <a href="@Url.Action("Create", "Admin", new { area = "Orchard.Queries", id = "Sql", query = Model.DecodedQuery })" class="btn btn-success">@T["Create"]</a>
+            </div>
+        </div>
+    }
+</div>
 
 @if (Model.Documents.Any())
 {
+    <span class="text-muted">@T["Query executed in {0} ms", Model.Elapsed.TotalMilliseconds]</span>
+
     @foreach (var document in Model.Documents)
     {
         <div>@Json.Serialize(document)</div>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Admin/Query.cshtml
@@ -7,6 +7,7 @@
 }
 
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js" depends-on="admin" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/javascript/javascript.js" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/sql/sql.js" at="Foot"></script>
 
 <h1>@RenderTitleSegments(T["SQL Query"])</h1>
@@ -24,7 +25,7 @@
 
     <div class="form-group">
         <label asp-for="Parameters">@T["Parameters"]</label>
-        <textarea asp-for="Parameters" rows="6" class="form-control"></textarea>
+        <textarea asp-for="Parameters" rows="1" class="form-control"></textarea>
         <span class="hint">@T["An optional Json object containing the parameter values for this query."]</span>
     </div>
 
@@ -45,49 +46,24 @@
 
     <div class="form-group">
         <label asp-for="RawParameters">@T["Final Parameters"]</label>
-        <textarea asp-for="RawParameters" rows="6" class="form-control"></textarea>
+        <textarea asp-for="RawParameters" rows="1" class="form-control"></textarea>
         <span class="hint">@T["The parameters that are sent to the SQL database."]</span>
     </div>
 }
 
 @if (Model.Documents.Any())
 {
-    
     @foreach (var document in Model.Documents)
     {
         <div>@Json.Serialize(document)</div>
     }
-
-    @*<table class="table table-striped table-hover table-responsive">
-        <thead>
-            <tr>
-                <th>#</th>
-                @foreach (var field in Model.Documents.First())
-                {
-                <th>@field.Name</th>
-                }
-            </tr>
-        </thead>
-        <tbody>
-            @{ int row = 1; }
-            @foreach (var document in Model.Documents)
-            {
-            <tr>
-                <th scope="row">@(row++)</th>
-                @foreach (var field in document)
-                {
-                    <td>@field.StringValue</td>
-                }
-            </tr>
-            }
-        </tbody>
-    </table>*@
 }
+
 <script at="Foot">
     $(function() {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: "text/x-sql", lineNumbers: true, viewportMargin: Infinity });
-        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.RawSql)'), { mode: "text/x-sql", lineNumbers: true, readonly: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.RawSql)'), { mode: "text/x-sql", lineNumbers: true, readonly: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.RawParameters)'), { mode: "javascript", readonly: true, json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Query-Sql.Link.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Query-Sql.Link.cshtml
@@ -1,0 +1,11 @@
+@model dynamic
+
+<div class="card">
+    <div class="card-block">
+        <h4>@T["SQL"]</h4>
+        <p class="hint">@T["Queries the SQL database."]</p>    
+    </div>
+    <div class="card-footer text-muted text-xs-right">
+        <a class="btn btn-primary btn-sm" asp-route-action="Create" asp-route-controller="Admin" asp-route-id="@Model.Name" asp-area="Orchard.Queries">@T["Add"]</a>
+    </div>
+</div>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/Query.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/Query.Fields.Edit.cshtml
@@ -2,7 +2,7 @@
 
 <fieldset class="form-group" asp-validation-class-for="Name">
     <label asp-for="Name">@T["Name"] <span asp-validation-for="Name"></span></label>
-    <input asp-for="Name" class="form-control text-muted" />
+    <input asp-for="Name" class="form-control text-muted" autofocus />
     <span class="hint">@T["The technical name of the query."]</span>
     <input asp-for="Source" type="hidden" />
 </fieldset>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Buttons.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,11 @@
+@model dynamic
+    
+@{ 
+    var base64Query = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes((string)Model.Query.Template ?? ""));
+}
+
+<a asp-action="Query" 
+   asp-controller="Admin" 
+   asp-area="Orchard.Queries" 
+   asp-route-query="@base64Query" 
+   class="btn btn-success btn-sm">@T["Run"]</a>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
@@ -6,10 +6,10 @@
 
 <fieldset class="form-check">
     <label class="form-check-label">
-        <input asp-for="ReturnContentItems" type="checkbox" class="form-check-input" checked="@Model.ReturnContentItems" /> @T["Return Content Items"]
-        <span class="hint">@T["Check to return the corresponding content items."]</span>
+        <input asp-for="ReturnDocuments" type="checkbox" class="form-check-input" checked="@Model.ReturnDocuments" /> @T["Return Documents"]
+        <span class="hint">@T["Check to return the corresponding documents."]</span>
     </label>
-    <span class="hint">@T["When checked, the result has to be a list of Content Item Version ids."]</span>
+    <span class="hint">@T["When checked, the result has to be a list of document ids."]</span>
 </fieldset>
 
 <fieldset class="form-group">

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
@@ -1,6 +1,7 @@
 @model Orchard.Queries.Sql.ViewModels.SqlQueryViewModel
 
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js" depends-on="admin" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/javascript/javascript.js" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/sql/sql.js" at="Foot"></script>
 
 <fieldset class="form-check">
@@ -18,6 +19,6 @@
 
 <script at="Foot">
     $(function () {
-        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "sql", lineNumbers: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "text/x-sql", lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
@@ -9,6 +9,7 @@
         <input asp-for="ReturnContentItems" type="checkbox" class="form-check-input" checked="@Model.ReturnContentItems" /> @T["Return Content Items"]
         <span class="hint">@T["Check to return the corresponding content items."]</span>
     </label>
+    <span class="hint">@T["When checked, the result has to be a list of Content Item Version ids."]</span>
 </fieldset>
 
 <fieldset class="form-group">

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.Edit.cshtml
@@ -1,0 +1,23 @@
+@model Orchard.Queries.Sql.ViewModels.SqlQueryViewModel
+
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js" depends-on="admin" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/sql/sql.js" at="Foot"></script>
+
+<fieldset class="form-check">
+    <label class="form-check-label">
+        <input asp-for="ReturnContentItems" type="checkbox" class="form-check-input" checked="@Model.ReturnContentItems" /> @T["Return Content Items"]
+        <span class="hint">@T["Check to return the corresponding content items."]</span>
+    </label>
+</fieldset>
+
+<fieldset class="form-group">
+    <label asp-for="Query">@T["Query"]</label>
+    <textarea asp-for="Query" rows="12" class="form-control"></textarea>
+    <span class="hint">@T["The SQL query to execute."]</span>
+</fieldset>
+
+<script at="Foot">
+    $(function () {
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "sql", lineNumbers: true, viewportMargin: Infinity });
+    });
+</script>

--- a/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/Orchard.Queries/Views/SqlQuery.SummaryAdmin.cshtml
@@ -1,0 +1,3 @@
+@model dynamic
+
+<span class="hint">@T["SQL query"]</span>

--- a/src/OrchardCore.Modules/Orchard.Recipes/Orchard.Recipes.csproj
+++ b/src/OrchardCore.Modules/Orchard.Recipes/Orchard.Recipes.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/Orchard.Recipes/Orchard.Recipes.csproj
+++ b/src/OrchardCore.Modules/Orchard.Recipes/Orchard.Recipes.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.ContentManagement/Orchard.ContentManagement.csproj
+++ b/src/OrchardCore/Orchard.ContentManagement/Orchard.ContentManagement.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.1" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.ContentManagement/Orchard.ContentManagement.csproj
+++ b/src/OrchardCore/Orchard.ContentManagement/Orchard.ContentManagement.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.1" />
-    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Abstractions" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.Data.Abstractions/Orchard.Data.Abstractions.csproj
+++ b/src/OrchardCore/Orchard.Data.Abstractions/Orchard.Data.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.Data.Abstractions/Orchard.Data.Abstractions.csproj
+++ b/src/OrchardCore/Orchard.Data.Abstractions/Orchard.Data.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.Data/Orchard.Data.csproj
+++ b/src/OrchardCore/Orchard.Data/Orchard.Data.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1026" />
-    <PackageReference Include="YesSql.Provider.MySql" Version="1.0.0-beta-1026" />
-    <PackageReference Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1026" />
-    <PackageReference Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1026" />
+    <PackageReference Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Provider.MySql" Version="1.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1034" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Orchard.Data/Orchard.Data.csproj
+++ b/src/OrchardCore/Orchard.Data/Orchard.Data.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1034" />
-    <PackageReference Include="YesSql.Provider.MySql" Version="1.0.0-beta-1034" />
-    <PackageReference Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1034" />
-    <PackageReference Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1034" />
+    <PackageReference Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1035" />
+    <PackageReference Include="YesSql.Provider.MySql" Version="1.0.0-beta-1035" />
+    <PackageReference Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1035" />
+    <PackageReference Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1035" />
   </ItemGroup>
 
 </Project>

--- a/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
@@ -13,7 +13,7 @@ namespace Orchard.Tests.Orchard.Queries
 
         private string FormatSql(string sql)
         {
-            return sql.Replace("\r\n", " ");
+            return sql.Replace("\r\n", " ").Replace("\n", " ");
         }
 
         [Theory]
@@ -25,8 +25,8 @@ namespace Orchard.Tests.Orchard.Queries
         [InlineData("SELECT a.b, c.d", "SELECT [tp_a].[b], [tp_c].[d];")]
         [InlineData("SELECT a as a1", "SELECT [a] AS a1;")]
         [InlineData("SELECT a as a1, b as b1", "SELECT [a] AS a1, [b] AS b1;")]
-        [InlineData("select avg(a)", "SELECT Avg([a]);")]
-        [InlineData("select min(*)", "SELECT Min(*);")]
+        [InlineData("select Avg(a)", "SELECT Avg([a]);")]
+        [InlineData("select Min(*)", "SELECT Min(*);")]
         [InlineData("select distinct a", "SELECT DISTINCT [a];")]
         public void ShouldParseSelectClause(string sql, string expectedSql)
         {
@@ -117,10 +117,11 @@ namespace Orchard.Tests.Orchard.Queries
         }
 
         [Theory]
-        [InlineData("select count(a) group by b", "SELECT COUNT([a]) GROUP BY [b];")]
-        [InlineData("select count(a) group by b, c", "SELECT COUNT([a]) GROUP BY [b], [c];")]
-        [InlineData("select count(a) group by b.c", "SELECT COUNT([a]) GROUP BY [tp_b].[c];")]
-        [InlineData("select count(a) from b as b1 group by b1.c", "SELECT COUNT([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
+        [InlineData("select count(a) group by b", "SELECT count([a]) GROUP BY [b];")]
+        [InlineData("select count(a) group by b, c", "SELECT count([a]) GROUP BY [b], [c];")]
+        [InlineData("select count(a) group by b.c", "SELECT count([a]) GROUP BY [tp_b].[c];")]
+        [InlineData("select count(a) from b as b1 group by b1.c", "SELECT count([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
+        [InlineData("select Month(a) as m group by Month(a)", "SELECT Month([a]) AS m GROUP BY Month([a]);")]
         public void ShouldParseGroupByClause(string sql, string expectedSql, object[] expectedParameters = null)
         {
             var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);

--- a/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
@@ -121,7 +121,7 @@ namespace Orchard.Tests.Orchard.Queries
         [InlineData("select count(a) group by b, c", "SELECT count([a]) GROUP BY [b], [c];")]
         [InlineData("select count(a) group by b.c", "SELECT count([a]) GROUP BY [tp_b].[c];")]
         [InlineData("select count(a) from b as b1 group by b1.c", "SELECT count([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
-        [InlineData("select Month(a) as m group by Month(a)", "SELECT datepart(month, [a]) AS m GROUP BY datepart(month, [a]);")]
+        [InlineData("select Month(a) as m group by Month(a)", "SELECT Month([a]) AS m GROUP BY Month([a]);")]
         public void ShouldParseGroupByClause(string sql, string expectedSql, object[] expectedParameters = null)
         {
             var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);

--- a/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Orchard.Queries.Sql;
 using Xunit;
 using YesSql;
-using YesSql.Providers.SqlServer;
+using YesSql.Provider.SqlServer;
 
 namespace Orchard.Tests.Orchard.Queries
 {
@@ -121,7 +121,7 @@ namespace Orchard.Tests.Orchard.Queries
         [InlineData("select count(a) group by b, c", "SELECT count([a]) GROUP BY [b], [c];")]
         [InlineData("select count(a) group by b.c", "SELECT count([a]) GROUP BY [tp_b].[c];")]
         [InlineData("select count(a) from b as b1 group by b1.c", "SELECT count([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
-        [InlineData("select Month(a) as m group by Month(a)", "SELECT Month([a]) AS m GROUP BY Month([a]);")]
+        [InlineData("select Month(a) as m group by Month(a)", "SELECT datepart(month, [a]) AS m GROUP BY datepart(month, [a]);")]
         public void ShouldParseGroupByClause(string sql, string expectedSql, object[] expectedParameters = null)
         {
             var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);

--- a/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/Orchard.Tests/Orchard.Queries/SqlParserTests.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using Orchard.Queries.Sql;
+using Xunit;
+using YesSql;
+using YesSql.Providers.SqlServer;
+
+namespace Orchard.Tests.Orchard.Queries
+{
+    public class SqlParserTests
+    {
+        private ISqlDialect _defaultDialect = new SqlServerDialect();
+        private string _defaultTablePrefix = "tp_";
+
+        private string FormatSql(string sql)
+        {
+            return sql.Replace("\r\n", " ");
+        }
+
+        [Theory]
+        [InlineData("select a", "SELECT [a];")]
+        [InlineData("select *", "SELECT *;")]
+        [InlineData("SELECT a", "SELECT [a];")]
+        [InlineData("SELECT a, b", "SELECT [a], [b];")]
+        [InlineData("SELECT a.b", "SELECT [tp_a].[b];")]
+        [InlineData("SELECT a.b, c.d", "SELECT [tp_a].[b], [tp_c].[d];")]
+        [InlineData("SELECT a as a1", "SELECT [a] AS a1;")]
+        [InlineData("SELECT a as a1, b as b1", "SELECT [a] AS a1, [b] AS b1;")]
+        [InlineData("select avg(a)", "SELECT Avg([a]);")]
+        [InlineData("select min(*)", "SELECT Min(*);")]
+        [InlineData("select distinct a", "SELECT DISTINCT [a];")]
+        public void ShouldParseSelectClause(string sql, string expectedSql)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Theory]
+        [InlineData("select a from t", "SELECT [a] FROM [tp_t];")]
+        [InlineData("SELECT a FROM t", "SELECT [a] FROM [tp_t];")]
+        [InlineData("SELECT a FROM t as t1", "SELECT [a] FROM [tp_t] AS t1;")]
+        [InlineData("SELECT a FROM t1, t2", "SELECT [a] FROM [tp_t1], [tp_t2];")]
+        public void ShouldParseFromClause(string sql, string expectedSql)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Theory]
+        [InlineData("select a where b", "SELECT [a] WHERE [b];")]
+        [InlineData("select a where b.b1", "SELECT [a] WHERE [tp_b].[b1];")]
+        [InlineData("select a where b = c", "SELECT [a] WHERE [b] = [c];")]
+        [InlineData("select a where b = c and d", "SELECT [a] WHERE [b] = [c] AND [d];")]
+        public void ShouldParseWhereClause(string sql, string expectedSql)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Theory]
+        [InlineData("select a where a", "SELECT [a] WHERE [a];")]
+        [InlineData("select a where ~a", "SELECT [a] WHERE ~[a];")]
+        [InlineData("select a where a = b", "SELECT [a] WHERE [a] = [b];")]
+        [InlineData("select a where a = true", "SELECT [a] WHERE [a] = @p0;", new object[] { true })]
+        [InlineData("select a where a = false", "SELECT [a] WHERE [a] = @p0;", new object[] { false })]
+        [InlineData("select a where a = 1", "SELECT [a] WHERE [a] = @p0;", new object[] { 1 })]
+        [InlineData("select a where a = 1.234", "SELECT [a] WHERE [a] = @p0;", new object[] { 1.234 })]
+        [InlineData("select a where a = 'foo'", "SELECT [a] WHERE [a] = @p0;", new object[] { "foo" })]
+        [InlineData("select a where a between b and c", "SELECT [a] WHERE [a] BETWEEN [b] AND [c];")]
+        [InlineData("select a where a not between b and c", "SELECT [a] WHERE [a] NOT BETWEEN [b] AND [c];")]
+        [InlineData("select a where a = b or c = d", "SELECT [a] WHERE [a] = [b] OR [c] = [d];")]
+        [InlineData("select a where (a = b) or (c = d)", "SELECT [a] WHERE ([a] = [b]) OR ([c] = [d]);")]
+        [InlineData("select a where (a = b) or (c = d) and e", "SELECT [a] WHERE ([a] = [b]) OR ([c] = [d]) AND [e];")]
+        [InlineData("select a where test(arg)", "SELECT [a] WHERE test([arg]);")]
+        [InlineData("select a where b in (1,2,3)", "SELECT [a] WHERE [b] IN (@p0, @p1, @p2);", new object[] { 1, 2, 3 })]
+        [InlineData("select a where b = (select Avg(c) from d)", "SELECT [a] WHERE [b] = (SELECT Avg([c]) FROM [tp_d]);")]
+        public void ShouldParseExpression(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+
+            if (expectedParameters != null)
+            {
+                for(var i=0; i<expectedParameters.Length; i++)
+                {
+                    Assert.Equal(expectedParameters[i], rawParameters["@p" + i]);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("select a from b inner join c on b.b1 = c.c1", "SELECT [a] FROM [tp_b] INNER JOIN [tp_c] ON [tp_b].[b1] = [tp_c].[c1];")]
+        [InlineData("select a from b as ba inner join c as ca on ba.b1 = ca.c1", "SELECT [a] FROM [tp_b] AS ba INNER JOIN [tp_c] AS ca ON ba.[b1] = ca.[c1];")]
+        public void ShouldParseJoinClause(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+
+        [Theory]
+        [InlineData("select a order by b", "SELECT [a] ORDER BY [b];")]
+        [InlineData("select a order by b, c", "SELECT [a] ORDER BY [b], [c];")]
+        [InlineData("select a order by b.c", "SELECT [a] ORDER BY [tp_b].[c];")]
+        [InlineData("select a from b as b1 order by b1.c", "SELECT [a] FROM [tp_b] AS b1 ORDER BY b1.[c];")]
+        [InlineData("select a order by b asc", "SELECT [a] ORDER BY [b] ASC;")]
+        [InlineData("select a order by b desc", "SELECT [a] ORDER BY [b] DESC;")]
+        public void ShouldParseOrderByClause(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Theory]
+        [InlineData("select count(a) group by b", "SELECT COUNT([a]) GROUP BY [b];")]
+        [InlineData("select count(a) group by b, c", "SELECT COUNT([a]) GROUP BY [b], [c];")]
+        [InlineData("select count(a) group by b.c", "SELECT COUNT([a]) GROUP BY [tp_b].[c];")]
+        [InlineData("select count(a) from b as b1 group by b1.c", "SELECT COUNT([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
+        public void ShouldParseGroupByClause(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Theory]
+        [InlineData("SELECT COUNT(CustomerID) GROUP BY Country HAVING COUNT(CustomerID) > 5", "SELECT COUNT([CustomerID]) GROUP BY [Country] HAVING COUNT([CustomerID]) > @p0;")]
+        public void ShouldParseHavingClause(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+
+        [Fact]
+        public void ShouldReturnErrorMessage()
+        {
+            var result = SqlParser.TryParse("SEL a", _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+
+            Assert.False(result);
+            Assert.Equal(1, messages.Count());
+            Assert.Contains("at line:0, col:0", messages.First());
+        }
+
+        [Theory]
+        [InlineData("SELECT a; -- this is a comment", "SELECT [a];")]
+        [InlineData("SELECT a; \n-- this is a comment", "SELECT [a];")]
+        [InlineData("SELECT /* comment */ a;", "SELECT [a];")]
+        [InlineData("SELECT /* comment \n comment */ a;", "SELECT [a];")]
+        public void ShouldParseComments(string sql, string expectedSql, object[] expectedParameters = null)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, out var rawQuery, out var rawParameters, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
+    }
+}

--- a/test/Orchard.Tests/Orchard.Tests.csproj
+++ b/test/Orchard.Tests/Orchard.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\OrchardCore.Modules\Orchard.Queries\Orchard.Queries.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore.Modules\Orchard.Tokens.Content\Orchard.Tokens.Content.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\Orchard.ContentManagement\Orchard.ContentManagement.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\Orchard.Data\Orchard.Data.csproj" />


### PR DESCRIPTION
Like lucene queries but with sql. Compared to Lucene, ad-hoc sql queries are not exposed with an Api, only for stored SQL queries.

Supports table prefix, parameter extraction. dialects (generates different sql for each database).

Parser is based on Irony. Parsing and converting would take less than 0.3ms on my machine.