### PR TITLE
Updated OpenIddict version and Nuget sources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,10 +2,11 @@
 <configuration>
   <packageSources>
     <!-- only use the feeds below -->
-    <clear/>
-    <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
+    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="Orchard2" value="https://www.myget.org/F/orchard2/api/v3/index.json" />
     <add key="icunet" value="https://www.myget.org/F/icu-dotnet/api/v3/index.json" />
+    <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
   </packageSources>
+  <disabledPackageSources />
 </configuration>

--- a/src/OrchardCore.Modules/Orchard.OpenId/Orchard.OpenId.csproj
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Orchard.OpenId.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.1" />
-    <PackageReference Include="OpenIddict" Version="1.0.0-beta2-0611" />
+    <PackageReference Include="OpenIddict" Version="1.0.0-beta2-0615" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR fixes https://github.com/OrchardCMS/Orchard2/issues/770

It updates Openiddict versión and decrement the priority of aspnet-contrib package source. Cause we need ASOS dependency from Openiddict it is resolved from default Nuget source but Openiddict dependency needs to be resolved form aspnet-contrib source.