### PR TITLE
Validating ClientSecret using password validators

### DIFF
--- a/src/OrchardCore.Modules/Orchard.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -16,7 +16,6 @@ namespace Orchard.OpenId.ViewModels
         public string LogoutRedirectUri { get; set; }
         public ClientType Type { get; set; }
         public bool SkipConsent { get; set; }
-        [StringLength(100, MinimumLength = 6)]
         [DataType(DataType.Password)]
         public string ClientSecret { get; set; }
         [DataType(DataType.Password)]

--- a/src/OrchardCore.Modules/Orchard.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -23,7 +23,6 @@ namespace Orchard.OpenId.ViewModels
         public ClientType Type { get; set; }
         public bool SkipConsent { get; set; }
         public bool UpdateClientSecret { get; set; }
-        [StringLength(100, MinimumLength = 6)]
         [DataType(DataType.Password)]
         public string ClientSecret { get; set; }
         [DataType(DataType.Password)]

--- a/src/OrchardCore.Modules/Orchard.OpenId/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Views/Admin/Create.cshtml
@@ -29,7 +29,7 @@
     </div>
     <div class="form-group" asp-validation-class-for="ClientSecret">
         <label asp-for="ClientSecret">@T["Client Secret"]</label>
-        <span asp-validation-for="ClientSecret" class="text-danger">@T["The Client Secret is required."]</span>
+        <span asp-validation-for="ClientSecret" class="text-danger"></span>
         <input asp-for="ClientSecret" class="form-control" autofocus />
     </div>
     <div class="form-group" asp-validation-class-for="ConfirmClientSecret">

--- a/src/OrchardCore.Modules/Orchard.OpenId/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Views/Admin/Edit.cshtml
@@ -39,7 +39,7 @@
     <div class="form-group collapse" id="clientSecretGroup" name="clientSecretGroup">
         <div class="form-group" asp-validation-class-for="ClientSecret">
             <label asp-for="ClientSecret">@T["Client Secret"]</label>
-            <span asp-validation-for="ClientSecret" class="text-danger">@T["The Client Secret is required."]</span>
+            <span asp-validation-for="ClientSecret" class="text-danger"></span>
             <input asp-for="ClientSecret" class="form-control" autofocus />
         </div>
         <div class="form-group" asp-validation-class-for="ConfirmClientSecret">


### PR DESCRIPTION
Uses same validation rules used for passwords also for client secret. The detailed error reported  is now provided to the user. It will avoid problems like this https://github.com/OrchardCMS/Orchard2/issues/777 because the validation error was not properly provided to the user.
