### PR TITLE
Fixing deferred task database locking

### DIFF
--- a/src/OrchardCore.Modules/Orchard.Commons/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Commons/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Modules;
@@ -39,11 +39,21 @@ namespace Orchard.Commons
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            // TODO: Order to be the late in the return pipeline
-            app.AddDeferredTasks();
-
             serviceProvider.AddTagHelpers(typeof(ResourcesTagHelper).GetTypeInfo().Assembly);
             serviceProvider.AddTagHelpers(typeof(ShapeTagHelper).GetTypeInfo().Assembly);
+        }
+    }
+
+    /// <summary>
+    /// Deferred tasks middleware is registered early as it has to run very late.
+    /// </summary>
+    public class DeferredTasksStartup : StartupBase
+    {
+        public override int Order => -50;
+
+        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            app.AddDeferredTasks();
         }
     }
 }

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/ModularTenantContainerMiddleware.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Orchard.Environment.Shell;
 
 namespace Microsoft.AspNetCore.Modules
@@ -14,18 +14,15 @@ namespace Microsoft.AspNetCore.Modules
         private readonly RequestDelegate _next;
         private readonly IShellHost _orchardHost;
         private readonly IRunningShellTable _runningShellTable;
-        private readonly ILogger _logger;
 
         public ModularTenantContainerMiddleware(
             RequestDelegate next,
             IShellHost orchardHost,
-            IRunningShellTable runningShellTable,
-            ILogger<ModularTenantContainerMiddleware> logger)
+            IRunningShellTable runningShellTable)
         {
             _next = next;
             _orchardHost = orchardHost;
             _runningShellTable = runningShellTable;
-            _logger = logger;
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -43,7 +40,10 @@ namespace Microsoft.AspNetCore.Modules
             {
                 var shellContext = _orchardHost.GetOrCreateShellContext(shellSetting);
 
-                using (var scope = shellContext.CreateServiceScope())
+                var existingRequestServices = httpContext.RequestServices;
+                var scope = shellContext.CreateServiceScope();
+
+                try
                 {
                     httpContext.RequestServices = scope.ServiceProvider;
 
@@ -72,7 +72,16 @@ namespace Microsoft.AspNetCore.Modules
                             }
                         }
                     }
+
+                    shellContext.RequestStarted();
                     await _next.Invoke(httpContext);
+                }
+                finally
+                {
+                    // We dispose httpContext.RequestServices and not a local reference in case another middleware changed it 
+                    (httpContext.RequestServices as IDisposable)?.Dispose();
+                    shellContext.RequestEnded();
+                    httpContext.RequestServices = existingRequestServices;
                 }
             }
         }

--- a/src/OrchardCore/Orchard.DeferredTasks.Abstractions/IDeferredTaskEngine.cs
+++ b/src/OrchardCore/Orchard.DeferredTasks.Abstractions/IDeferredTaskEngine.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Orchard.DeferredTasks
 {
     /// <summary>
-    /// Registers and executes tasks inside of an explicitly decribed shell context.
+    /// An implementation of this interface provides a way to enlist custom actions that
+    /// will be executed once the request is done. Each action receives a <see cref="DeferredTaskContext"/>.
+    /// Actions are executed in a new <see cref="IServiceProvider"/> scope.
     /// </summary>
     public interface IDeferredTaskEngine
     {

--- a/src/OrchardCore/Orchard.DeferredTasks.Abstractions/IDeferredTaskState.cs
+++ b/src/OrchardCore/Orchard.DeferredTasks.Abstractions/IDeferredTaskState.cs
@@ -1,9 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Orchard.DeferredTasks
 {
+    /// <summary>
+    /// An implementation of this interface is responsible for storing actions that need to be executed
+    /// at then end of the active request.
+    /// </summary>
     public interface IDeferredTaskState
     {
         IList<Func<DeferredTaskContext, Task>> Tasks { get; }

--- a/src/OrchardCore/Orchard.DeferredTasks/ApplicationBuilderExtensions.cs
+++ b/src/OrchardCore/Orchard.DeferredTasks/ApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 
 namespace Orchard.DeferredTasks
 {
@@ -6,7 +6,6 @@ namespace Orchard.DeferredTasks
     {
         public static IApplicationBuilder AddDeferredTasks(this IApplicationBuilder app)
         {
-            // TODO: Order to be the late in the return pipeline
             app.UseMiddleware<DeferredTaskMiddleware>();
 
             return app;

--- a/src/OrchardCore/Orchard.DeferredTasks/DeferredTaskEngine.cs
+++ b/src/OrchardCore/Orchard.DeferredTasks/DeferredTaskEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -25,7 +25,7 @@ namespace Orchard.DeferredTasks
 
         public async Task ExecuteTasksAsync(DeferredTaskContext context)
         {
-            for(var i=0; i < _deferredTaskState.Tasks.Count; i++)
+            for (var i = 0; i < _deferredTaskState.Tasks.Count; i++)
             {
                 var task = _deferredTaskState.Tasks[i];
 
@@ -33,7 +33,7 @@ namespace Orchard.DeferredTasks
                 {
                     await task(context);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     _logger.LogError("An error occured while processing a deferred task: {0}", e);
                 }

--- a/src/OrchardCore/Orchard.DeferredTasks/HttpContextTaskState.cs
+++ b/src/OrchardCore/Orchard.DeferredTasks/HttpContextTaskState.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Orchard.DeferredTasks
 {
+    /// <summary>
+    /// Maintains a list of tasks by using the active <see cref="HttpContext.Items"/> property
+    /// as storage.
+    /// </summary>
     public class HttpContextTaskState : IDeferredTaskState
     {
         private readonly static object Key = typeof(HttpContextTaskState);

--- a/src/OrchardCore/Orchard.Environment.Shell.Abstractions/Builders/ShellContext.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell.Abstractions/Builders/ShellContext.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Orchard.Environment.Shell.Builders.Models;
 using Orchard.Environment.Shell;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 
 namespace Orchard.Hosting.ShellBuilders
 {
@@ -12,6 +13,8 @@ namespace Orchard.Hosting.ShellBuilders
     public class ShellContext : IDisposable
     {
         private bool _disposed = false;
+        private int _refCount = 0;
+        private bool _released = false;
 
         public ShellSettings Settings { get; set; }
         public ShellBlueprint Blueprint { get; set; }
@@ -27,7 +30,55 @@ namespace Orchard.Hosting.ShellBuilders
         /// </summary>
         public IServiceScope CreateServiceScope()
         {
+            if (_disposed)
+            {
+                throw new InvalidOperationException("Can't use CreateServiceScope on a disposed context");
+            }
+
+            if (_released)
+            {
+                throw new InvalidOperationException("Can't use CreateServiceScope on a released context");
+            }
+
             return ServiceProvider.CreateScope();
+        }
+
+        /// <summary>
+        /// Whether the <see cref="ShellContext"/> instance has been released, for instance when a tenant is changed.
+        /// </summary>
+        public bool Released => _released;
+
+        /// <summary>
+        /// Returns the number of active requests on this tenant.
+        /// </summary>
+        public int ActiveRequests => _refCount;
+
+        public void RequestStarted()
+        {
+            Interlocked.Increment(ref _refCount);
+        }
+
+        public void RequestEnded()
+        {
+            var refCount = Interlocked.Decrement(ref _refCount);
+
+            if (_released && refCount == 0)
+            {
+                Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Mark the <see cref="ShellContext"/> has a candidate to be released.
+        /// </summary>
+        public void Release()
+        {
+            // When a tenant is changed and should be restarted, its shell context is replaced with a new one, 
+            // so that new request can't use it anymore. However some existing request might still be running and try to 
+            // resolve or use its services. We then call this method to count the remaining references and dispose it 
+            // when the number reached zero.
+
+            _released = true;
         }
 
         public void Dispose()

--- a/src/OrchardCore/Orchard.Environment.Shell/ShellHost.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/ShellHost.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -228,15 +228,9 @@ namespace Orchard.Environment.Shell
                 return Task.CompletedTask;
             }
 
-            ShellContext context;
-            if (!_shellContexts.TryGetValue(tenant, out context))
+            if (_shellContexts.TryRemove(tenant, out var context))
             {
-                return Task.CompletedTask;
-            }
-
-            if (_shellContexts.TryRemove(tenant, out context))
-            {
-                context.Dispose();
+                context.Release();
             }
 
             return Task.CompletedTask;
@@ -249,7 +243,7 @@ namespace Orchard.Environment.Shell
             if (_shellContexts.TryRemove(settings.Name, out context))
             {
                 _runningShellTable.Remove(settings);
-                context.Dispose();
+                context.Release();
             }
 
             GetOrCreateShellContext(settings);

--- a/src/OrchardCore/Orchard.Environment.Shell/ShellStateCoordinator.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/ShellStateCoordinator.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -83,10 +83,7 @@ namespace Orchard.Environment.Shell
                     {
                         Features = shellState.Features
                             .Where(FeatureShouldBeLoadedForStateChangeNotifications)
-                            .Select(x => new ShellFeature
-                            {
-                                Id = x.Id
-                            })
+                            .Select(x => new ShellFeature { Id = x.Id })
                             .ToArray()
                     };
 


### PR DESCRIPTION
- Prevent the deferred task engine from creating a deadlock by disposing the request
services before creating a new one.
- Ref count the requests on a shell context in order to release the shell context only when
all its requests are finished

Fixes #775