### PR TITLE
Adding RequireFeaturesAttribute

### DIFF
--- a/src/OrchardCore.Modules/Orchard.Autoroute/RemotePublishing/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Autoroute/RemotePublishing/Startup.cs
@@ -5,7 +5,7 @@ using Orchard.MetaWeblog;
 namespace Orchard.Autoroute.RemotePublishing
 {
 
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class RemotePublishingStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/Orchard.Body/RemotePublishing/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Body/RemotePublishing/Startup.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.AspNetCore.Modules;
+using Microsoft.AspNetCore.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Orchard.MetaWeblog;
 
 namespace Orchard.Body.RemotePublishing
 {
-
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class RemotePublishingStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/Orchard.Lists/Controllers/RemotePublishingController.cs
+++ b/src/OrchardCore.Modules/Orchard.Lists/Controllers/RemotePublishingController.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Mvc;
@@ -8,7 +8,7 @@ using Orchard.Lists.Models;
 
 namespace Orchard.Lists.Controllers
 {
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class RemotePublishingController : Controller
     {
         private readonly IContentManager _contentManager;

--- a/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/ListMetaWeblogDriver.cs
+++ b/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/ListMetaWeblogDriver.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Modules;
 using Orchard.ContentManagement.Display.ContentDisplay;
 using Orchard.ContentManagement.Display.Models;
@@ -7,7 +7,7 @@ using Orchard.Lists.Models;
 
 namespace Orchard.Lists.RemotePublishing
 {
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class ListMetaWeblogDriver : ContentPartDisplayDriver<ListPart>
     {
         public override IDisplayResult Display(ListPart listPart, BuildPartDisplayContext context)

--- a/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/MetaWeblogHandler.cs
+++ b/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/MetaWeblogHandler.cs
@@ -26,7 +26,7 @@ using YesSql;
 
 namespace Orchard.Lists.RemotePublishing
 {
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class MetaWeblogHandler : IXmlRpcHandler
     {
         private readonly IContentManager _contentManager;

--- a/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Lists/RemotePublishing/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Routing;
@@ -9,7 +9,7 @@ using Orchard.Core.XmlRpc;
 namespace Orchard.Lists.RemotePublishing
 {
 
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class RemotePublishingStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/Orchard.Markdown/RemotePublishing/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Markdown/RemotePublishing/Startup.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Modules;
+using Microsoft.AspNetCore.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Orchard.MetaWeblog;
 
 namespace Orchard.Markdown.RemotePublishing
 {
 
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class Startup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/Orchard.Title/RemotePublishing/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Title/RemotePublishing/Startup.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Modules;
+using Microsoft.AspNetCore.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Orchard.MetaWeblog;
 
 namespace Orchard.Title.RemotePublishing
 {
 
-    [Feature("Orchard.RemotePublishing")]
+    [RequireFeatures("Orchard.RemotePublishing")]
     public class RemotePublishingStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/FeatureAttribute.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/FeatureAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Microsoft.AspNetCore.Modules
 {
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Modules
     /// a specific feature by its name. This component will only
     /// be used if the feature is enabled.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class FeatureAttribute : Attribute
     {
         public FeatureAttribute(string featureName)

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/RequireFeaturesAttribute.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules.Abstractions/RequireFeaturesAttribute.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Modules
+{
+    /// <summary>
+    /// When used on a class, it will include the service only
+    /// if the specific features are enabled.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class RequireFeaturesAttribute : Attribute
+    {
+        public RequireFeaturesAttribute(string featureName)
+        {
+            RequiredFeatureNames = new string[] { featureName };
+        }
+
+        public RequireFeaturesAttribute(string featureName, params string[] otherFeatureNames)
+        {
+            var list = new List<string>(otherFeatureNames);
+            list.Add(featureName);
+
+            RequiredFeatureNames = list;
+        }
+
+        /// <summary>
+        /// The names of the required features.
+        /// </summary>
+        public IList<string> RequiredFeatureNames { get; }
+
+        public static IList<string> GetRequiredFeatureNamesForType(Type type)
+        {
+            var attribute = type.GetTypeInfo().GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault();
+
+            return attribute?.RequiredFeatureNames ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/OrchardCore/Orchard.Environment.Extensions/ExtensionManager.cs
+++ b/src/OrchardCore/Orchard.Environment.Extensions/ExtensionManager.cs
@@ -206,8 +206,7 @@ namespace Orchard.Environment.Extensions
                     return Enumerable.Empty<IFeatureInfo>();
                 }
 
-                return
-                    GetDependentFeatures(feature, _allOrderedFeatureInfos);
+                return GetDependentFeatures(feature, _allOrderedFeatureInfos);
             })).Value;
         }
 
@@ -242,12 +241,9 @@ namespace Orchard.Environment.Extensions
 
         private static string GetSourceFeatureNameForType(Type type, string extensionId)
         {
-            foreach (FeatureAttribute featureAttribute in type.GetTypeInfo().GetCustomAttributes(typeof(FeatureAttribute), false))
-            {
-                return featureAttribute.FeatureName;
-            }
+            var attribute = type.GetTypeInfo().GetCustomAttributes<FeatureAttribute>(false).FirstOrDefault();
 
-            return extensionId;
+            return attribute?.FeatureName ?? extensionId;
         }
 
         private void EnsureInitialized()
@@ -266,9 +262,9 @@ namespace Orchard.Environment.Extensions
 
                 var extensions = HarvestExtensions();
 
-                var loadedExtensions =
-                    new ConcurrentDictionary<string, ExtensionEntry>();
+                var loadedExtensions = new ConcurrentDictionary<string, ExtensionEntry>();
 
+                // Load all extensions in parallel
                 Parallel.ForEach(extensions, (extension) =>
                 {
                     if (!extension.Exists)
@@ -286,50 +282,36 @@ namespace Orchard.Environment.Extensions
                     loadedExtensions.TryAdd(extension.Id, entry);
                 });
 
-                var loadedFeatures =
-                    new Dictionary<string, FeatureEntry>();
+                var loadedFeatures = new Dictionary<string, FeatureEntry>();
+
+                // Get all valid types from any extension
+                var allTypesByExtension = loadedExtensions.SelectMany(extension =>
+                    extension.Value.ExportedTypes.Where(t => t.GetTypeInfo().IsClass && !t.GetTypeInfo().IsAbstract)
+                    .Select(type => new
+                    {
+                        ExtensionEntry = extension.Value,
+                        Type = type
+                    })).ToArray();
+
+                var typesByFeature = allTypesByExtension
+                    .GroupBy(typeByExtension => GetSourceFeatureNameForType(
+                        typeByExtension.Type, 
+                        typeByExtension.ExtensionEntry.ExtensionInfo.Id))
+                    .ToDictionary(
+                        group => group.Key, 
+                        group => group.Select(typesByExtension => typesByExtension.Type).ToArray());
 
                 foreach (var loadedExtension in loadedExtensions)
                 {
                     var extension = loadedExtension.Value;
 
-                    var extensionTypes = extension
-                        .ExportedTypes
-                        .Where(t => t.GetTypeInfo().IsClass && !t.GetTypeInfo().IsAbstract);
-
                     foreach (var feature in extension.ExtensionInfo.Features)
                     {
-                        var featureTypes = new HashSet<Type>();
+                        var featureTypes = typesByFeature[feature.Id];
 
-                        // Search for all types from the extensions that are not assigned to a different
-                        // feature.
-                        foreach (var type in extensionTypes)
+                        foreach (var type in featureTypes)
                         {
-                            string sourceFeature = GetSourceFeatureNameForType(type, extension.ExtensionInfo.Id);
-
-                            if (sourceFeature == feature.Id)
-                            {
-                                featureTypes.Add(type);
-                                _typeFeatureProvider.TryAdd(type, feature);
-                            }
-                        }
-
-                        // Search in other extensions for types that are assigned to this feature.
-                        var otherExtensionInfos = extensions.Where(x => x.Id != extension.ExtensionInfo.Id);
-
-                        foreach (var otherExtensionInfo in otherExtensionInfos)
-                        {
-                            var otherExtension = loadedExtensions[otherExtensionInfo.Id];
-                            foreach (var type in otherExtension.ExportedTypes)
-                            {
-                                string sourceFeature = GetSourceFeatureNameForType(type, null);
-
-                                if (sourceFeature == feature.Id)
-                                {
-                                    featureTypes.Add(type);
-                                    _typeFeatureProvider.TryAdd(type, feature);
-                                }
-                            }
+                            _typeFeatureProvider.TryAdd(type, feature);
                         }
 
                         loadedFeatures.Add(feature.Id, new CompiledFeatureEntry(feature, featureTypes));
@@ -337,6 +319,7 @@ namespace Orchard.Environment.Extensions
                 };
 
                 _extensions = loadedExtensions;
+
                 // Could we get rid of _allOrderedFeatureInfos and just have _features?
                 _features = loadedFeatures;
                 _allOrderedFeatureInfos = Order(loadedFeatures.Values.Select(x => x.FeatureInfo));
@@ -349,9 +332,7 @@ namespace Orchard.Environment.Extensions
             return featuresToOrder
                 .OrderBy(x => x.Id)
                 .Distinct()
-                .OrderByDependenciesAndPriorities(
-                    HasDependency,
-                    GetPriority)
+                .OrderByDependenciesAndPriorities(HasDependency, GetPriority)
                 .ToArray();
         }
 
@@ -412,8 +393,7 @@ namespace Orchard.Environment.Extensions
                     var manifestInfo = new ManifestInfo(configurationRoot, manifestConfiguration.Type);
                     
                     // Manifest tells you what your loading, subpath is where you are loading it
-                    var extensionInfo = _extensionProvider
-                        .GetExtensionInfo(manifestInfo, manifestsubPath);
+                    var extensionInfo = _extensionProvider.GetExtensionInfo(manifestInfo, manifestsubPath);
 
                     extensionSet.Add(extensionInfo);
                 }


### PR DESCRIPTION
This attribute doesn't change what feature owns a component, but will prevent a component from being part of the types of a shell if the specified features are not enabled.

For instance `RemotePublishingStartup` is in Autoroute and is responsible for handling custom slugs from Open Live Writer. This class in is the Autoroute module (single feature). If the feature Remote Publishing is not enabled, it doesn't make sense to have this startup class to run. Instead of create another feature in Autoroute that would depend on Remote Publishing, we just mark this class to require Remote Publishing. So when Remote Publishing will be enabled, the Autoroute feature will also include this new startup class. And we didn't have to create many specific little features. 

We can also mix `[Feature]` and `[RequireFeatures]`.