### PR TITLE
Auto watching module project razor files and static files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,9 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+[*.{json,csproj,props,targets}]
+indent_size = 2
+
 [*.cs]
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types                   = true : suggestion

--- a/src/Orchard.Cms.Web/Orchard.Cms.Web.csproj
+++ b/src/Orchard.Cms.Web/Orchard.Cms.Web.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <WatchOnlyModuleProjectRazorFiles>true</WatchOnlyModuleProjectRazorFiles>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
   </PropertyGroup>
 
@@ -31,10 +30,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Orchard.Cms.Web/watch.cmd
+++ b/src/Orchard.Cms.Web/watch.cmd
@@ -1,1 +1,0 @@
-dotnet watch msbuild /t:CopyModuleProjectRazorFiles

--- a/src/Orchard.Mvc.Web/OrchardCore.Mvc.csproj
+++ b/src/Orchard.Mvc.Web/OrchardCore.Mvc.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <WatchOnlyModuleProjectRazorFiles>true</WatchOnlyModuleProjectRazorFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,10 +30,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Orchard.Mvc.Web/watch.cmd
+++ b/src/Orchard.Mvc.Web/watch.cmd
@@ -1,1 +1,0 @@
-dotnet watch msbuild /t:CopyModuleProjectRazorFiles

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/Microsoft.AspNetCore.Modules.csproj
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/Microsoft.AspNetCore.Modules.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="1.1.2" />
+	<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="1.1.1" />
+	<PackageReference Include="Microsoft.Extensions.Localization" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
   </ItemGroup>
   

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/ModuleProjectContentFileProvider.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/ModuleProjectContentFileProvider.cs
@@ -6,22 +6,26 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Primitives;
 
-namespace Orchard.Mvc
+namespace Microsoft.AspNetCore.Modules
 {
     /// <summary>
     /// This custom <see cref="IFileProvider"/> implementation provides the file contents
-    /// of Module Project Razor files while in a development environment.
+    /// of Module Project Content files while in a development environment.
     /// </summary>
-    public class ModuleProjectRazorFileProvider : IFileProvider
+    public class ModuleProjectContentFileProvider : IFileProvider
     {
         private const string MappingFileFolder = "obj";
-        private const string MappingFileName = "ModuleProjectRazorFiles.map";
+        private const string MappingFileName = "ModuleProjectContentFiles.map";
 
         private static Dictionary<string, string> _paths;
         private static object _synLock = new object();
 
-        public ModuleProjectRazorFileProvider(string rootPath)
+        private string _contentPath;
+
+        public ModuleProjectContentFileProvider(string rootPath, string contentPath)
         {
+            _contentPath = '/' + contentPath.Replace('\\', '/').TrimStart('/');
+
             if (_paths != null)
             {
                 return;
@@ -56,9 +60,16 @@ namespace Orchard.Mvc
 
         public IFileInfo GetFileInfo(string subpath)
         {
-            if (subpath != null && _paths.ContainsKey(subpath))
+            if (subpath == null)
             {
-                return new PhysicalFileInfo(new FileInfo(_paths[subpath]));
+                return null;
+            }
+
+            var path = _contentPath + subpath;
+
+            if (_paths.ContainsKey(path))
+            {
+                return new PhysicalFileInfo(new FileInfo(_paths[path]));
             }
 
             return null;
@@ -66,11 +77,6 @@ namespace Orchard.Mvc
 
         public IChangeToken Watch(string filter)
         {
-            if (filter != null && _paths.ContainsKey(filter))
-            {
-                return new PollingFileChangeToken(new FileInfo(_paths[filter]));
-            }
-
             return null;
         }
     }

--- a/src/OrchardCore/Microsoft.AspNetCore.Modules/ModuleProjectContentFileProvider.cs
+++ b/src/OrchardCore/Microsoft.AspNetCore.Modules/ModuleProjectContentFileProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Modules
 
         public ModuleProjectContentFileProvider(string rootPath, string contentPath)
         {
-            _contentPath = '/' + contentPath.Replace('\\', '/').TrimStart('/');
+            _contentPath = '/' + contentPath.Replace('\\', '/').Trim('/');
 
             if (_paths != null)
             {

--- a/src/OrchardCore/Orchard.DisplayManagement/Theming/ThemingFileProvider.cs
+++ b/src/OrchardCore/Orchard.DisplayManagement/Theming/ThemingFileProvider.cs
@@ -22,7 +22,7 @@ namespace Orchard.DisplayManagement.Theming
 
         public IFileInfo GetFileInfo(string subpath)
         {
-            if (subpath == "/Views/_ViewImports.cshtml")
+            if (subpath == "/_ViewImports.cshtml")
             {
                 return _viewImportsFileInfo;
             }

--- a/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -96,11 +96,11 @@ namespace Orchard.Mvc
 
         internal static IMvcCoreBuilder AddModularRazorViewEngine(this IMvcCoreBuilder builder, IServiceProvider services)
         {
-            var env = services.GetRequiredService<IHostingEnvironment>();
-
             return builder.AddRazorViewEngine(options =>
             {
                 options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
+
+                var env = services.GetRequiredService<IHostingEnvironment>();
 
                 if (env.IsDevelopment())
                 {

--- a/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Modules;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
@@ -95,9 +96,12 @@ namespace Orchard.Mvc
 
         internal static IMvcCoreBuilder AddModularRazorViewEngine(this IMvcCoreBuilder builder, IServiceProvider services)
         {
+            var _hostingEnvironment = services.GetRequiredService<IHostingEnvironment>();
+
             return builder.AddRazorViewEngine(options =>
             {
                 options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
+                options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(_hostingEnvironment));
             });
         }
 

--- a/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -104,7 +104,7 @@ namespace Orchard.Mvc
 
                 if (env.IsDevelopment())
                 {
-                    options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(env));
+                    options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(env.ContentRootPath));
                 }
             });
         }

--- a/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -96,12 +96,16 @@ namespace Orchard.Mvc
 
         internal static IMvcCoreBuilder AddModularRazorViewEngine(this IMvcCoreBuilder builder, IServiceProvider services)
         {
-            var _hostingEnvironment = services.GetRequiredService<IHostingEnvironment>();
+            var env = services.GetRequiredService<IHostingEnvironment>();
 
             return builder.AddRazorViewEngine(options =>
             {
                 options.ViewLocationExpanders.Add(new CompositeViewLocationExpanderProvider());
-                options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(_hostingEnvironment));
+
+                if (env.IsDevelopment())
+                {
+                    options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(env));
+                }
             });
         }
 

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -19,20 +19,16 @@ namespace Orchard.Mvc
         private static ConcurrentDictionary<string, string> _paths;
         private static object _synLock = new object();
 
-        private IHostingEnvironment _hostingEnvironment;
-
-        public ModuleProjectRazorFileProvider(IHostingEnvironment hostingEnvironment)
+        public ModuleProjectRazorFileProvider(IHostingEnvironment env)
         {
-            _hostingEnvironment = hostingEnvironment;
-
             if (_paths == null)
             {
                 lock (_synLock)
                 {
                     if (_paths == null)
                     {
-                        var path = Path.Combine(hostingEnvironment.ContentRootPath, "obj",
-                            hostingEnvironment.ApplicationName + ".ModuleProjectRazorFilesMapping.txt");
+                        var path = Path.Combine(env.ContentRootPath, "obj",
+                            env.ApplicationName + ".ModuleProjectRazorFilesMapping.txt");
 
                         if (File.Exists(path))
                         {

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Primitives;
@@ -15,12 +14,12 @@ namespace Orchard.Mvc
     /// </summary>
     public class ModuleProjectRazorFileProvider : IFileProvider
     {
-        private const string MappingFileRelativePath = "obj\\ModuleProjectRazorFiles.map";
+        private const string MappingFilePath = "obj\\ModuleProjectRazorFiles.map";
 
         private static ConcurrentDictionary<string, string> _paths;
         private static object _synLock = new object();
 
-        public ModuleProjectRazorFileProvider(IHostingEnvironment env)
+        public ModuleProjectRazorFileProvider(string rootPath)
         {
             if (_paths == null)
             {
@@ -28,7 +27,7 @@ namespace Orchard.Mvc
                 {
                     if (_paths == null)
                     {
-                        var path = Path.Combine(env.ContentRootPath, MappingFileRelativePath);
+                        var path = Path.Combine(rootPath, MappingFilePath);
 
                         if (File.Exists(path))
                         {

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
@@ -16,6 +15,8 @@ namespace Orchard.Mvc
     /// </summary>
     public class ModuleProjectRazorFileProvider : IFileProvider
     {
+        private const string MappingFileRelativePath = "obj\\ModuleProjectRazorFiles.map";
+
         private static ConcurrentDictionary<string, string> _paths;
         private static object _synLock = new object();
 
@@ -27,8 +28,7 @@ namespace Orchard.Mvc
                 {
                     if (_paths == null)
                     {
-                        var path = Path.Combine(env.ContentRootPath, "obj",
-                            env.ApplicationName + ".ModuleProjectRazorFilesMapping.txt");
+                        var path = Path.Combine(env.ContentRootPath, MappingFileRelativePath);
 
                         if (File.Exists(path))
                         {

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -22,26 +22,28 @@ namespace Orchard.Mvc
 
         public ModuleProjectRazorFileProvider(string rootPath)
         {
-            if (_paths == null)
+            if (_paths != null)
             {
-                lock (_synLock)
+                return;
+            }
+
+            lock (_synLock)
+            {
+                if (_paths == null)
                 {
-                    if (_paths == null)
+                    var path = Path.Combine(rootPath, MappingFileFolder, MappingFileName);
+
+                    if (File.Exists(path))
                     {
-                        var path = Path.Combine(rootPath, MappingFileFolder, MappingFileName);
+                        var paths = File.ReadAllLines(path)
+                            .Select(x => x.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
+                            .Where(x => x.Length == 2).ToDictionary(x => x[1].Replace('\\', '/'), x => x[0]);
 
-                        if (File.Exists(path))
-                        {
-                            var paths = File.ReadAllLines(path)
-                                .Select(x => x.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
-                                .Where(x => x.Length == 2).ToDictionary(x => x[1].Replace('\\', '/'), x => x[0]);
-
-                            _paths = new Dictionary<string, string>(paths);
-                        }
-                        else
-                        {
-                            _paths = new Dictionary<string, string>();
-                        }
+                        _paths = new Dictionary<string, string>(paths);
+                    }
+                    else
+                    {
+                        _paths = new Dictionary<string, string>();
                     }
                 }
             }

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
+
+namespace Orchard.Mvc
+{
+    /// <summary>
+    /// This custom <see cref="IFileProvider"/> implementation provides the file contents
+    /// of Module Project Razor files while in a development environment.
+    /// </summary>
+    public class ModuleProjectRazorFileProvider : IFileProvider
+    {
+        private static ConcurrentDictionary<string, string> _paths;
+        private static object _synLock = new object();
+
+        private IHostingEnvironment _hostingEnvironment;
+
+        public ModuleProjectRazorFileProvider(IHostingEnvironment hostingEnvironment)
+        {
+            _hostingEnvironment = hostingEnvironment;
+
+            if (_paths == null)
+            {
+                lock (_synLock)
+                {
+                    if (_paths == null)
+                    {
+                        var path = Path.Combine(hostingEnvironment.ContentRootPath, "obj",
+                            hostingEnvironment.ApplicationName + ".ModuleProjectRazorFilesMap.txt");
+
+                        if (File.Exists(path))
+                        {
+                            var paths = File.ReadAllLines(path)
+                                .Select(x => x.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
+                                .Where(x => x.Count() == 2).ToDictionary(x => x[1].Replace('\\', '/'), x => x[0]);
+
+                            _paths = new ConcurrentDictionary<string, string>(paths);
+                        }
+                        else
+                        {
+                            _paths = new ConcurrentDictionary<string, string>();
+                        }
+                    }
+                }
+            }
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+            return null;
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            if (_paths.TryGetValue(subpath, out var path))
+            {
+                return new PhysicalFileInfo(new FileInfo(path));
+            }
+            
+            return null;
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            if (_paths.TryGetValue(filter, out var path))
+            {
+                return new PollingFileChangeToken(new FileInfo(path));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -14,7 +14,8 @@ namespace Orchard.Mvc
     /// </summary>
     public class ModuleProjectRazorFileProvider : IFileProvider
     {
-        private const string MappingFilePath = "obj\\ModuleProjectRazorFiles.map";
+        private const string MappingFileFolder = "obj";
+        private const string MappingFileName = "ModuleProjectRazorFiles.map";
 
         private static Dictionary<string, string> _paths;
         private static object _synLock = new object();
@@ -27,7 +28,7 @@ namespace Orchard.Mvc
                 {
                     if (_paths == null)
                     {
-                        var path = Path.Combine(rootPath, MappingFilePath);
+                        var path = Path.Combine(rootPath, MappingFileFolder, MappingFileName);
 
                         if (File.Exists(path))
                         {

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.FileProviders;
@@ -16,7 +16,7 @@ namespace Orchard.Mvc
     {
         private const string MappingFilePath = "obj\\ModuleProjectRazorFiles.map";
 
-        private static ConcurrentDictionary<string, string> _paths;
+        private static Dictionary<string, string> _paths;
         private static object _synLock = new object();
 
         public ModuleProjectRazorFileProvider(string rootPath)
@@ -33,13 +33,13 @@ namespace Orchard.Mvc
                         {
                             var paths = File.ReadAllLines(path)
                                 .Select(x => x.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
-                                .Where(x => x.Count() == 2).ToDictionary(x => x[1].Replace('\\', '/'), x => x[0]);
+                                .Where(x => x.Length == 2).ToDictionary(x => x[1].Replace('\\', '/'), x => x[0]);
 
-                            _paths = new ConcurrentDictionary<string, string>(paths);
+                            _paths = new Dictionary<string, string>(paths);
                         }
                         else
                         {
-                            _paths = new ConcurrentDictionary<string, string>();
+                            _paths = new Dictionary<string, string>();
                         }
                     }
                 }
@@ -53,19 +53,19 @@ namespace Orchard.Mvc
 
         public IFileInfo GetFileInfo(string subpath)
         {
-            if (_paths.TryGetValue(subpath, out var path))
+            if (_paths.ContainsKey(subpath))
             {
-                return new PhysicalFileInfo(new FileInfo(path));
+                return new PhysicalFileInfo(new FileInfo(_paths[subpath]));
             }
-            
+
             return null;
         }
 
         public IChangeToken Watch(string filter)
         {
-            if (_paths.TryGetValue(filter, out var path))
+            if (_paths.ContainsKey(filter))
             {
-                return new PollingFileChangeToken(new FileInfo(path));
+                return new PollingFileChangeToken(new FileInfo(_paths[filter]));
             }
 
             return null;

--- a/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/Orchard.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -32,7 +32,7 @@ namespace Orchard.Mvc
                     if (_paths == null)
                     {
                         var path = Path.Combine(hostingEnvironment.ContentRootPath, "obj",
-                            hostingEnvironment.ApplicationName + ".ModuleProjectRazorFilesMap.txt");
+                            hostingEnvironment.ApplicationName + ".ModuleProjectRazorFilesMapping.txt");
 
                         if (File.Exists(path))
                         {

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.csproj
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <None Include="OrchardCore.AsBundle.targets" Pack="true">
-      <PackagePath>build\netstandard1.6\OrchardCore.AsBundle.targets</PackagePath>
+      <PackagePath>build\$(TargetFramework)\OrchardCore.AsBundle.targets</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -44,7 +44,7 @@
       Lines="@(ModuleProjectRazorFilesMapping)"
       Condition="'@(ModuleProjectRazorFilesMapping)' != ''"
       Overwrite="true"
-      Encoding="Unicode"
+      Encoding="utf-8"
       ContinueOnError="true" />
 
     <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -47,19 +47,19 @@
       Encoding="utf-8"
       ContinueOnError="true" />
 
-	  <ItemGroup>
+    <ItemGroup>
       <ModuleProjectContentFiles Include="%(ModuleProjectReferences.RootDir)%(Directory)Content\**\*">
         <ProjectName>%(Filename)</ProjectName>
       </ModuleProjectContentFiles>
-		  <ModuleProjectContentFilesMapping
-			  Include="%(ModuleProjectContentFiles.FullPath)|\Packages\%(ModuleProjectContentFiles.ProjectName)\Content\%(RecursiveDir)%(Filename)%(Extension)">
-		  </ModuleProjectContentFilesMapping>
-	  </ItemGroup>
+      <ModuleProjectContentFilesMapping
+        Include="%(ModuleProjectContentFiles.FullPath)|\Packages\%(ModuleProjectContentFiles.ProjectName)\Content\%(RecursiveDir)%(Filename)%(Extension)">
+      </ModuleProjectContentFilesMapping>
+    </ItemGroup>
 
-	  <Message Text="Generating module project content files mapping file"
-		  Condition="'@(ModuleProjectContentFilesMapping)' != ''" Importance="high" />
+    <Message Text="Generating module project content files mapping file"
+      Condition="'@(ModuleProjectContentFilesMapping)' != ''" Importance="high" />
 
-	  <WriteLinesToFile
+    <WriteLinesToFile
       File="obj\ModuleProjectContentFiles.map"
       Lines="@(ModuleProjectContentFilesMapping)"
       Condition="'@(ModuleProjectContentFilesMapping)' != ''"
@@ -67,7 +67,7 @@
       Encoding="utf-8"
       ContinueOnError="true" />
 
-	  <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">
+    <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">
       <Output TaskParameter="Include" ItemName="MvcContentRazorFiles"/>
     </CreateItem>
     <ItemGroup Condition="'@(MvcRazorFilesToCompile)' == ''">

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -47,7 +47,27 @@
       Encoding="utf-8"
       ContinueOnError="true" />
 
-    <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">
+	  <ItemGroup>
+      <ModuleProjectContentFiles Include="%(ModuleProjectReferences.RootDir)%(Directory)Content\**\*">
+        <ProjectName>%(Filename)</ProjectName>
+      </ModuleProjectContentFiles>
+		  <ModuleProjectContentFilesMapping
+			  Include="%(ModuleProjectContentFiles.FullPath)|\Packages\%(ModuleProjectContentFiles.ProjectName)\Content\%(RecursiveDir)%(Filename)%(Extension)">
+		  </ModuleProjectContentFilesMapping>
+	  </ItemGroup>
+
+	  <Message Text="Generating module project content files mapping file"
+		  Condition="'@(ModuleProjectContentFilesMapping)' != ''" Importance="high" />
+
+	  <WriteLinesToFile
+      File="obj\ModuleProjectContentFiles.map"
+      Lines="@(ModuleProjectContentFilesMapping)"
+      Condition="'@(ModuleProjectContentFilesMapping)' != ''"
+      Overwrite="true"
+      Encoding="utf-8"
+      ContinueOnError="true" />
+
+	  <CreateItem Include="@(Content)" Condition="'%(Extension)'=='.cshtml'">
       <Output TaskParameter="Include" ItemName="MvcContentRazorFiles"/>
     </CreateItem>
     <ItemGroup Condition="'@(MvcRazorFilesToCompile)' == ''">
@@ -58,7 +78,7 @@
   <Target Name="CleanPackageAssets" AfterTargets="Clean"
           Condition="'$(IgnorePackageAssets)' != 'true' And Exists('Packages')">
     <ItemGroup>
-     <AllPackageAssetFiles Include="Packages\**" />
+      <AllPackageAssetFiles Include="Packages\**" />
     </ItemGroup>
     <Delete
       Files="@(AllPackageAssetFiles)"

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -36,7 +36,7 @@
       </ModuleProjectRazorFilesMapping>
     </ItemGroup>
 
-    <Message Text="Generating module project razor files mapping file : $(MSBuildProjectName)"
+    <Message Text="Generating module project razor files mapping file"
       Condition="'@(ModuleProjectRazorFilesMapping)' != ''" Importance="high" />
 
     <WriteLinesToFile

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -1,9 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <ModuleProjectRazorFilesMapping>obj/$(MSBuildProjectName).ModuleProjectRazorFilesMapping.txt</ModuleProjectRazorFilesMapping>
-  </PropertyGroup>
-
   <!--
     Defines msbuild tasks on a Bundle package to copy all modules assets (projects and packages) to the "Packages" folder.
   -->
@@ -40,11 +36,11 @@
       </ModuleProjectRazorFilesMapping>
     </ItemGroup>
 
-    <Message Text="Generate the mapping file of module project razor files : $(MSBuildProjectName)"
-      Condition="'@(ModuleProjectRazorFiles)' != ''" Importance="high" />
+    <Message Text="Generating module project razor files mapping file : $(MSBuildProjectName)"
+      Condition="'@(ModuleProjectRazorFilesMapping)' != ''" Importance="high" />
 
     <WriteLinesToFile
-      File="$(ModuleProjectRazorFilesMapping)"
+      File="$(BaseIntermediateOutputPath)ModuleProjectRazorFiles.map"
       Lines="@(ModuleProjectRazorFilesMapping)"
       Condition="'@(ModuleProjectRazorFilesMapping)' != ''"
       Overwrite="true"

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ModuleProjectReferencesFile>obj/$(MSBuildProjectFile).ModuleProjectReferences.txt</ModuleProjectReferencesFile>
+    <ModuleProjectRazorFilesMap>obj/$(MSBuildProjectName).ModuleProjectRazorFilesMap.txt</ModuleProjectRazorFilesMap>
   </PropertyGroup>
 
   <!--
@@ -31,13 +31,22 @@
       ContinueOnError="true">
     </MSBuild>
 
-    <Message Text="Generating module project references file: $(MSBuildProjectName)"
-      Condition="'@(ModuleProjectReferences)' != ''" Importance="high" />
+    <ItemGroup>
+      <ModuleProjectRazorFiles Include="%(ModuleProjectReferences.RootDir)%(Directory)**\*.cshtml">
+        <ProjectName>%(Filename)</ProjectName>
+      </ModuleProjectRazorFiles>
+      <ModuleProjectRazorFilesMap
+        Include="%(ModuleProjectRazorFiles.FullPath)|\Packages\%(ModuleProjectRazorFiles.ProjectName)\%(RecursiveDir)%(Filename)%(Extension)">
+      </ModuleProjectRazorFilesMap>
+    </ItemGroup>
+
+    <Message Text="Generate the module project razor files map file: $(MSBuildProjectName)"
+      Condition="'@(ModuleProjectRazorFiles)' != ''" Importance="high" />
 
     <WriteLinesToFile
-      File="$(ModuleProjectReferencesFile)"
-      Lines="@(ModuleProjectReferences)"
-      Condition="'@(ModuleProjectReferences)' != ''"
+      File="$(ModuleProjectRazorFilesMap)"
+      Lines="@(ModuleProjectRazorFilesMap)"
+      Condition="'@(ModuleProjectRazorFiles)' != ''"
       Overwrite="true"
       Encoding="Unicode"
       ContinueOnError="true" />
@@ -61,39 +70,6 @@
     <RemoveDir
       Directories="Packages\%(AllPackageAssetFiles.RecursiveDir)"
       ContinueOnError="true" />
-  </Target>
-
-  <Target Name="ClearProjectReferences" BeforeTargets="_CollectWatchProjects"
-          Condition="'$(WatchOnlyModuleProjectRazorFiles)' == 'true'">
-    <ItemGroup>
-      <ProjectReference Remove="@(ProjectReference)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="WatchModuleProjectRazorFiles" BeforeTargets="_WriteGeneratedWatchList"
-          Condition="'$(WatchOnlyModuleProjectRazorFiles)' == 'true' And Exists('$(ModuleProjectReferencesFile)')">
-    <ReadLinesFromFile File="$(ModuleProjectReferencesFile)">
-      <Output TaskParameter="Lines" ItemName="ModuleProjectReferences" />
-    </ReadLinesFromFile>
-    <ItemGroup>
-      <Watch Include="%(ModuleProjectReferences.RootDir)%(Directory)**\*.cshtml" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CopyModuleProjectRazorFiles"
-          Condition="'$(WatchOnlyModuleProjectRazorFiles)' == 'true' And Exists('$(ModuleProjectReferencesFile)')">
-    <ReadLinesFromFile File="$(ModuleProjectReferencesFile)">
-      <Output TaskParameter="Lines" ItemName="ModuleProjectReferences" />
-    </ReadLinesFromFile>
-    <ItemGroup>
-      <ModuleProjectRazorFiles Include="%(ModuleProjectReferences.RootDir)%(Directory)**\*.cshtml">
-        <ProjectName>%(Filename)</ProjectName>
-      </ModuleProjectRazorFiles>
-    </ItemGroup>
-    <Message Text="Copying module project razor files: $(MSBuildProjectName)" Importance="high" />
-    <Copy
-      SourceFiles="@(ModuleProjectRazorFiles)"
-      DestinationFolder="Packages\%(ProjectName)\%(RecursiveDir)" />
   </Target>
 
   <!--

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -40,7 +40,7 @@
       Condition="'@(ModuleProjectRazorFilesMapping)' != ''" Importance="high" />
 
     <WriteLinesToFile
-      File="$(BaseIntermediateOutputPath)ModuleProjectRazorFiles.map"
+      File="obj\ModuleProjectRazorFiles.map"
       Lines="@(ModuleProjectRazorFilesMapping)"
       Condition="'@(ModuleProjectRazorFilesMapping)' != ''"
       Overwrite="true"

--- a/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
+++ b/src/OrchardCore/OrchardCore.AsBundle/OrchardCore.AsBundle.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ModuleProjectRazorFilesMap>obj/$(MSBuildProjectName).ModuleProjectRazorFilesMap.txt</ModuleProjectRazorFilesMap>
+    <ModuleProjectRazorFilesMapping>obj/$(MSBuildProjectName).ModuleProjectRazorFilesMapping.txt</ModuleProjectRazorFilesMapping>
   </PropertyGroup>
 
   <!--
@@ -35,18 +35,18 @@
       <ModuleProjectRazorFiles Include="%(ModuleProjectReferences.RootDir)%(Directory)**\*.cshtml">
         <ProjectName>%(Filename)</ProjectName>
       </ModuleProjectRazorFiles>
-      <ModuleProjectRazorFilesMap
+      <ModuleProjectRazorFilesMapping
         Include="%(ModuleProjectRazorFiles.FullPath)|\Packages\%(ModuleProjectRazorFiles.ProjectName)\%(RecursiveDir)%(Filename)%(Extension)">
-      </ModuleProjectRazorFilesMap>
+      </ModuleProjectRazorFilesMapping>
     </ItemGroup>
 
-    <Message Text="Generate the module project razor files map file: $(MSBuildProjectName)"
+    <Message Text="Generate the mapping file of module project razor files : $(MSBuildProjectName)"
       Condition="'@(ModuleProjectRazorFiles)' != ''" Importance="high" />
 
     <WriteLinesToFile
-      File="$(ModuleProjectRazorFilesMap)"
-      Lines="@(ModuleProjectRazorFilesMap)"
-      Condition="'@(ModuleProjectRazorFiles)' != ''"
+      File="$(ModuleProjectRazorFilesMapping)"
+      Lines="@(ModuleProjectRazorFilesMapping)"
+      Condition="'@(ModuleProjectRazorFilesMapping)' != ''"
       Overwrite="true"
       Encoding="Unicode"
       ContinueOnError="true" />

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.csproj
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.csproj
@@ -7,10 +7,10 @@
   <!-- Add the OrchardCore.AsModule.props file in the package -->
   <ItemGroup>
     <None Include="OrchardCore.AsModule.props" Pack="true">
-      <PackagePath>build\netstandard1.6\OrchardCore.AsModule.props</PackagePath>
+      <PackagePath>build\$(TargetFramework)\OrchardCore.AsModule.props</PackagePath>
     </None>
     <None Include="Package.Build.props" Pack="true">
-      <PackagePath>build\netstandard1.6\Package.Build.props</PackagePath>
+      <PackagePath>build\$(TargetFramework)\Package.Build.props</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
@@ -47,7 +47,7 @@
   
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Package.Build.props" Pack="true">
-      <PackagePath>build\netstandard1.6\$(PackageId).props</PackagePath>
+      <PackagePath>build\$(TargetFramework)\$(PackageId).props</PackagePath>
     </None>
     <None Include="**\*" Exclude="$(ExcludedFiles)" Pack="true">
       <PackagePath>assets\$(PackageId)\</PackagePath>

--- a/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
+++ b/src/OrchardCore/OrchardCore.AsModule/OrchardCore.AsModule.props
@@ -21,7 +21,7 @@
       File="obj\$(ModuleType).txt"
       Lines="$(ModuleManifest)"
       Overwrite="true"
-      Encoding="Unicode"
+      Encoding="utf-8"
       ContinueOnError="true" />
   </Target>
 


### PR DESCRIPTION
Here, through msbuild we create a `ModuleProjectRazorFilesMap.txt` in the `/obj` folder wich contains module razor files paths and their related paths in the `/Packages` folder.

Then, through a custom razor file provider we can watch module project razor files. This file provider do nothing if there is no `/obj` folder with the map file or no module referenced as projects.

Todo: maybe better to check earlier if the map file doesn't exist, this to just not add this file provider.

Just did it quickly, working in progress ...