### PR TITLE
Fixes issue #830 

### DIFF
--- a/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
@@ -64,7 +64,7 @@ namespace Orchard.Environment.Shell
         private string ObtainValue(IDictionary<string, string> configuration, string key)
         {
             configuration.TryGetValue(key, out string value);
-            return (item.Value ?? "~");
+            return (value ?? "~");
         }
 
         private string ObtainSettingsPath(string tenantPath) => Path.Combine(tenantPath, "Settings.txt");

--- a/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
@@ -50,12 +50,21 @@ namespace Orchard.Environment.Shell
                 Optional = false
             });
 
-            foreach (var item in configuration)
-            {
-                configurationProvider.Set($"{item.Key}", item.Value ?? "~");
-            }
+            configurationProvider.Set(name, null);
+            configurationProvider.Set($"{name}:RequestUrlHost", ObtainValue(configuration,$"{name}:RequestUrlHost"));
+            configurationProvider.Set($"{name}:RequestUrlPrefix", ObtainValue(configuration,$"{name}:RequestUrlPrefix"));
+            configurationProvider.Set($"{name}:DatabaseProvider", ObtainValue(configuration,$"{name}:DatabaseProvider"));
+            configurationProvider.Set($"{name}:TablePrefix", ObtainValue(configuration,$"{name}:TablePrefix"));
+            configurationProvider.Set($"{name}:ConnectionString", ObtainValue(configuration,$"{name}:ConnectionString"));
+            configurationProvider.Set($"{name}:State", ObtainValue(configuration,$"{name}:State"));
 
             configurationProvider.Commit();
+        }
+
+        private string ObtainValue(IDictionary<string, string> configuration, string key)
+        {
+            configuration.TryGetValue(key, out string value);
+            return (item.Value ?? "~");
         }
 
         private string ObtainSettingsPath(string tenantPath) => Path.Combine(tenantPath, "Settings.txt");

--- a/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/ShellSettingsConfigurationProvider.cs
@@ -50,21 +50,12 @@ namespace Orchard.Environment.Shell
                 Optional = false
             });
 
-            configurationProvider.Set(name, null);
-            configurationProvider.Set($"{name}:RequestUrlHost", ObtainValue(configuration,$"{name}:RequestUrlHost"));
-            configurationProvider.Set($"{name}:RequestUrlPrefix", ObtainValue(configuration,$"{name}:RequestUrlPrefix"));
-            configurationProvider.Set($"{name}:DatabaseProvider", ObtainValue(configuration,$"{name}:DatabaseProvider"));
-            configurationProvider.Set($"{name}:TablePrefix", ObtainValue(configuration,$"{name}:TablePrefix"));
-            configurationProvider.Set($"{name}:ConnectionString", ObtainValue(configuration,$"{name}:ConnectionString"));
-            configurationProvider.Set($"{name}:State", ObtainValue(configuration,$"{name}:State"));
+            foreach (var item in configuration)
+            {
+                configurationProvider.Set($"{item.Key}", item.Value ?? "~");
+            }
 
             configurationProvider.Commit();
-        }
-
-        private string ObtainValue(IDictionary<string, string> configuration, string key)
-        {
-            configuration.TryGetValue(key, out string value);
-            return value;
         }
 
         private string ObtainSettingsPath(string tenantPath) => Path.Combine(tenantPath, "Settings.txt");

--- a/src/OrchardCore/Orchard.Parser.Yaml/Yaml/YamlConfigurationFileParser.cs
+++ b/src/OrchardCore/Orchard.Parser.Yaml/Yaml/YamlConfigurationFileParser.cs
@@ -84,7 +84,7 @@ namespace Orchard.Parser.Yaml
             {
                 throw new FormatException(string.Format("FormatError_KeyIsDuplicated({0})", key));
             }
-            _data[key] = yamlNodeValue.Value;
+            _data[key] = (yamlNodeValue.Value == "~" || yamlNodeValue.Value == "null") ? null : yamlNodeValue.Value;
             ExitContext();
         }
 


### PR DESCRIPTION
- writes out "~" for nulls in settings.txt
- correctly handles "null" and "~" when parsing yaml file

