### PR TITLE
#839 Module startup classes now get the same instance of service collection

### DIFF
--- a/src/OrchardCore/Orchard.Environment.Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/Orchard.Environment.Shell/Builders/ShellContainerFactory.cs
@@ -87,16 +87,18 @@ namespace Orchard.Environment.Shell.Builders
                 var feature = blueprint.Dependencies.FirstOrDefault(x => x.Key == startup.GetType()).Value.FeatureInfo;
 
                 ServiceCollection featureServiceCollection;
-                ServiceCollection startupServices = new ServiceCollection();
-
+                
                 if (!featureServiceCollections.TryGetValue(feature, out featureServiceCollection))
                 {
                     featureServiceCollections.Add(feature, featureServiceCollection = new ServiceCollection());
                 }
 
-                startup.ConfigureServices(startupServices);
-                tenantServiceCollection.Add(startupServices);
-                featureServiceCollection.Add(startupServices);
+                int previousTenantServiceCount = tenantServiceCollection.Count;
+                startup.ConfigureServices(tenantServiceCollection);
+
+                // Determine and store any new services the startup class has added for this feature 
+                var newTenantServices = tenantServiceCollection.Skip(previousTenantServiceCount);
+                featureServiceCollection.Add(newTenantServices);
             }
 
             (moduleServiceProvider as IDisposable).Dispose();


### PR DESCRIPTION
This is a proposed fix for #839 so that modules can call AddMvcCore multiple times. This is important to support libraries like [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle/tree/master/Swashbuckle.Core) and [Microsoft.AspNetCore.Mvc.Versioning](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Versioning). See #839 for more details.

I'm not completely knowledgable of the side-effects this change might have, it does give Startup classes more opportunity to mess with the tenant services collection, unsure if that's a good or bad thing - I can tell you this code doesn't fully handle the case where ServiceCollection.Remove is used by the startup class as I didn't want to complicate things for that edge case. 

My testing has consisted of creating a new CMS site from scratch and clicking around the admin menus.