### PR TITLE
OpenId UserInfo endpoint hint and POST

### DIFF
--- a/src/OrchardCore.Modules/Orchard.OpenId/Controllers/UserInfoController.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Controllers/UserInfoController.cs
@@ -25,8 +25,8 @@ namespace Orchard.OpenId.Controllers
             _userManager = userManager;
         }
 
-        // GET: /Orchard.OpenId/UserInfo/Me
-        [HttpGet]
+        // GET/POST: /Orchard.OpenId/UserInfo/Me
+        [AcceptVerbs("GET", "POST")]
         [IgnoreAntiforgeryToken]
         [Produces("application/json")]
         public async Task<IActionResult> Me()

--- a/src/OrchardCore.Modules/Orchard.OpenId/Views/OpenIdSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Views/OpenIdSettings.Edit.cshtml
@@ -128,7 +128,7 @@
                 <input asp-for="EnableUserInfoEndpoint" class="form-check-input" />@T["Enable User Info Endpoint"]
             </label>
         </div>
-        <span class="hint">@T["Enables action /Orchard.OpenId/Access/Userinfo"]</span>
+        <span class="hint">@T["Enables action /Orchard.OpenId/UserInfo/Me"]</span>
     </fieldset>
 
     <h3>Flows</h3>


### PR DESCRIPTION
Resolves #842 by updating the hint below the UserInfo endpoint with the correct path and, on request of @PinpointTownes, added POST to the Me action.

**Note:** I chose to use the `AcceptVerbsAttribute` to specify multiple verbs as a clean solution (AFAIK you can't specify both HttpGet and HttpPost on the same action). The alternative would be to create a `MePOST` action with `[HttpPost, ActionName = nameof(Me)`, but that seemed overkill.