### PR TITLE
Fixes Theme ordering

### DIFF
--- a/src/OrchardCore.Modules/Orchard.Commons/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.Commons/Startup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Modules;
@@ -25,7 +25,6 @@ namespace Orchard.Commons
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddThemingHost();
             services.AddDeferredTasks();
             services.AddDataAccess();
             services.AddBackgroundTasks();

--- a/src/OrchardCore/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/Orchard.DisplayManagement/ServiceCollectionExtensions.cs
@@ -36,23 +36,7 @@ namespace Orchard.DisplayManagement
         /// <returns></returns>
         public static IServiceCollection AddThemingHost(this IServiceCollection services)
         {
-		    services.Configure<MvcOptions>((options) =>
-            {
-                options.Filters.Add(typeof(ModelBinderAccessorFilter));
-            });
-
-            services.Configure<RazorViewEngineOptions>(options =>
-            {
-                options.FileProviders.Add(new ThemingFileProvider());
-            });
-
-            services.AddScoped<IApplicationFeatureProvider<ViewsFeature>, ThemingViewsFeatureProvider>();
-            services.AddScoped<IUpdateModelAccessor, LocalModelBinderAccessor>();
-            services.AddScoped<IViewLocationExpanderProvider, ThemeAwareViewLocationExpanderProvider>();
-
             services.AddSingleton<IExtensionDependencyStrategy, ThemeExtensionDependencyStrategy>();
-            services.AddSingleton<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
-
             services.AddSingleton<IFeatureBuilderEvents, ThemeFeatureBuilderEvents>();
 
             return services;
@@ -62,8 +46,20 @@ namespace Orchard.DisplayManagement
         {
 		    services.Configure<MvcOptions>((options) =>
             {
+                options.Filters.Add(typeof(ModelBinderAccessorFilter));
                 options.Filters.Add(typeof(NotifyFilter));
             });
+
+            services.AddScoped<IUpdateModelAccessor, LocalModelBinderAccessor>();
+
+            services.Configure<RazorViewEngineOptions>(options =>
+            {
+                options.FileProviders.Add(new ThemingFileProvider());
+            });
+
+            services.AddSingleton<IShapeTemplateViewEngine, RazorShapeTemplateViewEngine>();
+            services.AddScoped<IApplicationFeatureProvider<ViewsFeature>, ThemingViewsFeatureProvider>();
+            services.AddScoped<IViewLocationExpanderProvider, ThemeAwareViewLocationExpanderProvider>();
 
             services.AddScoped<IShapeTemplateHarvester, BasicShapeTemplateHarvester>();
             services.AddTransient<IShapeTableManager, DefaultShapeTableManager>();

--- a/src/OrchardCore/OrchardCore.Cms/ServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Cms/ServiceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Orchard.DisplayManagement;
 using Orchard.Environment.Commands;
 using Orchard.Environment.Extensions;
 using Orchard.Environment.Extensions.Manifests;
@@ -15,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddOrchardCms(this IServiceCollection services, IConfiguration configuration)
         {
+            services.AddThemingHost();
             services.AddManifestDefinition("Theme.txt", "theme");
             services.AddExtensionLocation("Themes");
             services.AddSitesFolder("App_Data", "Sites");


### PR DESCRIPTION
Fixes #864.

- 2 Theme services at the tenant level are not seen by singletons at the host level. It was working when `AddThemingHost()` was called from the web app. Since 4 March it is called from `Orchard.Commons`.

- The suggestion is to put only these 2 services in `AddThemingHost()`, move other services in `AddTheming()`, and call `AddThemingHost()` from `OrchardCore.Cms`.

**Repro**

- Set a module priority > 0 or create a Theme whose name starts with `A`.

- Then through the debugger you can see that themes (or the theme you created), which need to keep higher priorities, are not at the end of the list (highest priorities).