### PR TITLE
Update ThemingFileProvider.cs

### DIFF
--- a/src/OrchardCore/Orchard.DisplayManagement/Theming/ThemingFileProvider.cs
+++ b/src/OrchardCore/Orchard.DisplayManagement/Theming/ThemingFileProvider.cs
@@ -22,7 +22,7 @@ namespace Orchard.DisplayManagement.Theming
 
         public IFileInfo GetFileInfo(string subpath)
         {
-            if (subpath == "/Views/_ViewImports.cshtml")
+            if (subpath == "/_ViewImports.cshtml")
             {
                 return _viewImportsFileInfo;
             }


### PR DESCRIPTION
`/Views/_ViewImports.cshtml` is never requested by the razor engine, but `/_ViewImports.cshtml` is. This to really provide a `_viewImportsFileInfo` when there is no `_ViewImports.cshtml`.

