### PR TITLE
Update RazorPage.cs

### DIFF
--- a/src/OrchardCore/Orchard.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/Orchard.DisplayManagement/Razor/RazorPage.cs
@@ -202,7 +202,7 @@ namespace Orchard.DisplayManagement.Razor
 
             var zone = ThemeLayout[name];
 
-            if (required && zone != null && !zone.Items.Any())
+            if (required && zone != null && zone.Items.Count == 0)
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }


### PR DESCRIPTION
Prevent `RenderSectionAsync()` from always failing when `required = true` and `zone != null`.