### PR TITLE
Use OpenIdSettings.Audiences as the default resources when no "resource" parameter is specified

### DIFF
--- a/src/Orchard.Cms.Web/Orchard.Cms.Web.csproj
+++ b/src/Orchard.Cms.Web/Orchard.Cms.Web.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Remove="NLog.config" />
     <Content Include="NLog.config" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard2/issues/870 plus a few other things (e.g the `Accept()` POST action didn't correctly check whether the application was allowed to use the specified flow).