### PR TITLE
Fixes Scope validation in OpenId

### DIFF
--- a/src/OrchardCore.Modules/Orchard.OpenId/Services/OpenIdConfiguration.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Services/OpenIdConfiguration.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using OpenIddict;
 using Orchard.Environment.Shell;
 using Orchard.OpenId.Models;

--- a/src/OrchardCore.Modules/Orchard.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Startup.cs
@@ -47,7 +47,7 @@ namespace Orchard.OpenId
             services.AddScoped<INavigationProvider, AdminMenu>();
 
             services.AddScoped<IDisplayDriver<ISite>, OpenIdSiteSettingsDisplayDriver>();
-            services.AddScoped<IOpenIdService, OpenIdService>();
+            services.AddSingleton<IOpenIdService, OpenIdService>();
             services.AddRecipeExecutionStep<OpenIdSettingsStep>();
             services.AddRecipeExecutionStep<OpenIdApplicationStep>();
 


### PR DESCRIPTION

- With the last dev branch which uses `BuildServiceProvider(validateScopes: true)` there is still a scope validation issue. **Repro**: fresh setup using the `cms.recipe`.

- Here a suggestion quickly done just to show where the issue is.