### PR TITLE
Uses "Microsoft.NET.Sdk" for modules

### DIFF
--- a/src/OrchardCore.Modules/Orchard.Admin/Orchard.Admin.csproj
+++ b/src/OrchardCore.Modules/Orchard.Admin/Orchard.Admin.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
+++ b/src/OrchardCore.Modules/Orchard.Alias/Orchard.Alias.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
+++ b/src/OrchardCore.Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Body/Orchard.Body.csproj
+++ b/src/OrchardCore.Modules/Orchard.Body/Orchard.Body.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Commons/Orchard.Commons.csproj
+++ b/src/OrchardCore.Modules/Orchard.Commons/Orchard.Commons.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.ContentFields/Orchard.ContentFields.csproj
+++ b/src/OrchardCore.Modules/Orchard.ContentFields/Orchard.ContentFields.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.ContentPreview/Orchard.ContentPreview.csproj
+++ b/src/OrchardCore.Modules/Orchard.ContentPreview/Orchard.ContentPreview.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.ContentTypes/Orchard.ContentTypes.csproj
+++ b/src/OrchardCore.Modules/Orchard.ContentTypes/Orchard.ContentTypes.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Contents/Orchard.Contents.csproj
+++ b/src/OrchardCore.Modules/Orchard.Contents/Orchard.Contents.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.CustomSettings/Orchard.CustomSettings.csproj
+++ b/src/OrchardCore.Modules/Orchard.CustomSettings/Orchard.CustomSettings.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
+++ b/src/OrchardCore.Modules/Orchard.Demo/Orchard.Demo.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Deployment.Remote/Orchard.Deployment.Remote.csproj
+++ b/src/OrchardCore.Modules/Orchard.Deployment.Remote/Orchard.Deployment.Remote.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Deployment/Orchard.Deployment.csproj
+++ b/src/OrchardCore.Modules/Orchard.Deployment/Orchard.Deployment.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Diagnostics/Orchard.Diagnostics.csproj
+++ b/src/OrchardCore.Modules/Orchard.Diagnostics/Orchard.Diagnostics.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.DynamicCache/Orchard.DynamicCache.csproj
+++ b/src/OrchardCore.Modules/Orchard.DynamicCache/Orchard.DynamicCache.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Flows/Orchard.Flows.csproj
+++ b/src/OrchardCore.Modules/Orchard.Flows/Orchard.Flows.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
+++ b/src/OrchardCore.Modules/Orchard.Layers/Orchard.Layers.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Liquid/Orchard.Liquid.csproj
+++ b/src/OrchardCore.Modules/Orchard.Liquid/Orchard.Liquid.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Lists/Orchard.Lists.csproj
+++ b/src/OrchardCore.Modules/Orchard.Lists/Orchard.Lists.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Localization/Orchard.Localization.csproj
+++ b/src/OrchardCore.Modules/Orchard.Localization/Orchard.Localization.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
+++ b/src/OrchardCore.Modules/Orchard.Lucene/Orchard.Lucene.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Markdown/Orchard.Markdown.csproj
+++ b/src/OrchardCore.Modules/Orchard.Markdown/Orchard.Markdown.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Menu/Orchard.Menu.csproj
+++ b/src/OrchardCore.Modules/Orchard.Menu/Orchard.Menu.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Modules/Orchard.Modules.csproj
+++ b/src/OrchardCore.Modules/Orchard.Modules/Orchard.Modules.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Mvc.HelloWorld/Orchard.Mvc.HelloWorld.csproj
+++ b/src/OrchardCore.Modules/Orchard.Mvc.HelloWorld/Orchard.Mvc.HelloWorld.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Navigation/Orchard.Navigation.csproj
+++ b/src/OrchardCore.Modules/Orchard.Navigation/Orchard.Navigation.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.OpenId/Orchard.OpenId.csproj
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Orchard.OpenId.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Queries/Orchard.Queries.csproj
+++ b/src/OrchardCore.Modules/Orchard.Queries/Orchard.Queries.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Roles/Orchard.Roles.csproj
+++ b/src/OrchardCore.Modules/Orchard.Roles/Orchard.Roles.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Settings/Orchard.Settings.csproj
+++ b/src/OrchardCore.Modules/Orchard.Settings/Orchard.Settings.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Setup/Orchard.Setup.csproj
+++ b/src/OrchardCore.Modules/Orchard.Setup/Orchard.Setup.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Templates/Orchard.Templates.csproj
+++ b/src/OrchardCore.Modules/Orchard.Templates/Orchard.Templates.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Tenants/Orchard.Tenants.csproj
+++ b/src/OrchardCore.Modules/Orchard.Tenants/Orchard.Tenants.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Themes/Orchard.Themes.csproj
+++ b/src/OrchardCore.Modules/Orchard.Themes/Orchard.Themes.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Title/Orchard.Title.csproj
+++ b/src/OrchardCore.Modules/Orchard.Title/Orchard.Title.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Users/Orchard.Users.csproj
+++ b/src/OrchardCore.Modules/Orchard.Users/Orchard.Users.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/OrchardCore.Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
+++ b/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
+++ b/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
+++ b/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
@@ -1,9 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
+++ b/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
+++ b/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #948 

In case we opt to the solution to use `Microsoft.NET.Sdk` for modules, this is what this PR do.

- This because now razor intellisense works with `Microsoft.NET.Sdk`.