### PR TITLE
Implement missing methods of OpenIddict.Core.IOpenIddictApplicationStore'1

### DIFF
--- a/src/OrchardCore.Modules/Orchard.OpenId/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/Orchard.OpenId/Services/OpenIdApplicationStore.cs
@@ -68,6 +68,22 @@ namespace Orchard.OpenId.Services
             return _session.Query<OpenIdApplication, OpenIdApplicationIndex>(o => o.LogoutRedirectUri == url).FirstOrDefaultAsync();
         }
 
+        public async Task<OpenIdApplication[]> FindByLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var apps = await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(o => o.LogoutRedirectUri == address).ListAsync();
+            return apps == null ? new OpenIdApplication[] { } : apps.ToArray();
+        }
+
+        public async Task<OpenIdApplication[]> FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var apps = await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(o => o.LogoutRedirectUri == address).ListAsync();
+            return apps == null ? new OpenIdApplication[] { } : apps.ToArray();
+        }
+
         public Task<string> GetClientTypeAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)


### PR DESCRIPTION
I just cloned Orchard2 master for the first time, and got the following compilation errors when building in VS 2017. After implementing these methods, every project in the solution built successfully.

One concern I have with the change is the `FindByRedirectUriAsync` method. Since `RedirectUri` is not a property of the `OpenIdApplicationIndex` I simply filter on the `LogoutRedirectUri` property just like the `FindByLogoutRedirectUriAsync` method.

Should the `RedirectUri` be added to the `OpenIdApplicationIndex`?

Fixes compilation errors:

'OpenIdApplicationStore' does not implement interface member 'IOpenIddictApplicationStore<OpenIdApplication>.FindByLogoutRedirectUriAsync(string, CancellationToken)'

'OpenIdApplicationStore' does not implement interface member 'IOpenIddictApplicationStore<OpenIdApplication>.FindByRedirectUriAsync(string, CancellationToken)'